### PR TITLE
Minor changes to install guide.

### DIFF
--- a/articles/quantum-InstallConfig.md
+++ b/articles/quantum-InstallConfig.md
@@ -72,7 +72,7 @@ In this section you will clone the quantum samples & libraries, and run a sample
   > [!TIP]
   > If you are running on macOS and the `code` command is missing, you may need to [install the command line interface for Visual Studio Code](https://code.visualstudio.com/docs/editor/command-line).
 
-3. From the terminal in (standalone, or the embedded terminal in Visual Studio Code), run the teleport sample program:
+3. From the terminal (standalone, or the embedded terminal in Visual Studio Code), run the teleport sample program:
   ```bash
   $ cd Samples/Teleportation/
   $ dotnet run


### PR DESCRIPTION
This PR adds a link (currently broken, but should go live with the release) to the README.md for the Python interop sample and adds in a version number specification to the `dotnet new -i` command. The latter should work for the released package, as it uses a wildcard to select patch and prerelease versions. I tested in PowerShell, cmd and Bash (WSL) to make sure that the wildcard doesn't accidentally get globbed at the shell, and it seems to work.