### PR TITLE
Fix links to phase est, etc. docs.

### DIFF
--- a/articles/libraries/characterization.md
+++ b/articles/libraries/characterization.md
@@ -125,7 +125,7 @@ The prior distribution $\Pr(x)$ has support over $2^n$ hypothetical values of $x
 This means that if we need a highly accurate estimate of $x$ then Bayesian phase estimation may need prohibitive memory and processing time.
 While for some applications, such as quantum simulation, the limitted accuracy required does not preclude such methods other applications,
 such as Shor's algorithm, cannot use exact Bayesian inference within its phase estimation step.  For this reason, we also provide implementations
-for approximate Bayesian methods such as [random walk phase estimation (RWPE)](xref:microsoft.research.quantum.randomwalkphaseestimation) and also non-Bayesian approaches such as [robust phase estimation](xref:microsoft.quantum.canon.robustphaseestimation).
+for approximate Bayesian methods such as [random walk phase estimation (RWPE)](xref:microsoft.research.quantum.randomwalkphaseestimation.randomwalkphaseestimation) and also non-Bayesian approaches such as [robust phase estimation](xref:microsoft.quantum.canon.robustphaseestimation).
 
 ### Robust Phase Estimation ###
 

--- a/articles/libraries/error-correction.md
+++ b/articles/libraries/error-correction.md
@@ -3,7 +3,7 @@
 title: Q# standard libraries - error correction | Microsoft Docs
 description: Q# standard libraries - error correction
 author: QuantumWriter
-uid: microsoft.quantum.libraries.data-structures
+uid: microsoft.quantum.libraries.error-correction
 ms.author: martinro@microsoft.com 
 ms.date: 12/11/2017
 ms.topic: article


### PR DESCRIPTION
This PR fixes links that were broken as a result of the quantum / quantum-nc split.