### PR TITLE
Typo fixes in AssertProb and Measure

### DIFF
--- a/api/prelude/microsoft.quantum.primitive.assertprob.yml
+++ b/api/prelude/microsoft.quantum.primitive.assertprob.yml
@@ -13,7 +13,7 @@ remarks: >2
    using (register = Qubit[1]) {
        H(register[0]);
        AssertProb([PauliZ], register, One, 0.5,
-           "Measuring in conjugate basis did not give 50/50 results.");
+           "Measuring in conjugate basis did not give 50/50 results.", 1e-5);
    }
    ```
 syntax: 'operation AssertProb (bases : Pauli[], qubits : Qubit[], result : Result, prob : Double, msg : String, tol : Double) : ()'

--- a/api/prelude/microsoft.quantum.primitive.measure.yml
+++ b/api/prelude/microsoft.quantum.primitive.measure.yml
@@ -12,13 +12,13 @@ summary: >2
            \frac12 \braket{
                \psi \mid|
                \left(
-                   \boldone + P_0 \otimes P_1 \otimes \cdots \otimes P_N
+                   \boldone + P_0 \otimes P_1 \otimes \cdots \otimes P_N-1
                \right) \mid|
                \psi
            },
    \end{align}
    where $P_i$ is the $i$th element of `bases`, and where
-   $N = \texttt{Length}(\texttt{paulis})$.
+   $N = \texttt{Length}(\texttt{bases})$.
    That is, measurement returns a `Result` $d$ such that the eigenvalue of the
    observed measurement effect is $(-1)^d$.
 remarks: >2-


### PR DESCRIPTION
This fixes the following feedback from Balint Rikker:

1. Typo in the documentation for AssertProb:
https://quantum.uservoice.com/forums/906946-samples-and-documentation/suggestions/33472849-incorrect-example-in-assertprob-documentation

2. Typos in documentation for Measure:
https://docs.microsoft.com/en-us/qsharp/api/prelude/microsoft.quantum.primitive.measure?view=qsharp-preview
In the formula for the probability distribution, the tensor product of the Pauli bases should be indexed from either 0 to N-1, or from 1 to N as there are only N of them.

P0⊗P1⊗⋯⊗PN

On the line below, the explanation defines 'N=Length(paulis)' but instead of 'paulis', it should be 'bases', to match the type signature below.
