### PR TITLE
Register should be an array of Qubits

### DIFF
--- a/articles/libraries/control-flow.md
+++ b/articles/libraries/control-flow.md
@@ -52,7 +52,7 @@ In Q#, this might get represented as a `for` loop over a register:
 ```qsharp
 /// # Summary
 /// Applies $H$ to all qubits in a register.
-operation HAll(register : Qubit) : () {
+operation HAll(register : Qubit[]) : () {
     body {
         for (idxQubit in 0..Length(register) - 1) {
             H(register[idxQubit]);


### PR DESCRIPTION
Example doesn't compile, as a single Qubit  is passed as the operation parameter, but it should represent an array which is then enumerated in the body.