### PR TITLE
An addition for Controlled statement documentation

### DIFF
--- a/articles/quantum-QR-TypeModel.md
+++ b/articles/quantum-QR-TypeModel.md
@@ -330,5 +330,5 @@ For example, `((Controlled(Rz))(controls, (0.1, target))` would be
 a valid invocation of `Controlled(Rz)`.
 
 As another example, `CNOT(control, target)` analogue can be implemented as `(Controlled(X))([control], target)`. 
-If a target should be controlled by 2 control qubits (CCNOT analogue) we can use `(Contolled(X))([control1;control2], target) statement`.
+If a target should be controlled by 2 control qubits (CCNOT analogue) we can use `(Contolled(X))([control1;control2], target)` statement.
 

--- a/articles/quantum-QR-TypeModel.md
+++ b/articles/quantum-QR-TypeModel.md
@@ -329,6 +329,6 @@ so `Controlled(Rz)` has type
 For example, `((Controlled(Rz))(controls, (0.1, target))` would be 
 a valid invocation of `Controlled(Rz)`.
 
-As another example, `CNOT(control, target)` analogue can be implemented as `(Controlled(X))([control], target)`. 
-If a target should be controlled by 2 control qubits (CCNOT analogue) we can use `(Contolled(X))([control1;control2], target)` statement.
+As another example, `CNOT(control, target)` can be implemented as `(Controlled(X))([control], target)`. 
+If a target should be controlled by 2 control qubits (CCNOT), we can use `(Controlled(X))([control1;control2], target)` statement.
 

--- a/articles/quantum-QR-TypeModel.md
+++ b/articles/quantum-QR-TypeModel.md
@@ -329,3 +329,6 @@ so `Controlled(Rz)` has type
 For example, `((Controlled(Rz))(controls, (0.1, target))` would be 
 a valid invocation of `Controlled(Rz)`.
 
+As another example, `CNOT(control, target)` analogue can be implemented as `(Controlled(X))([control], target)`. 
+If a target should be controlled by 2 control qubits (CCNOT analogue) we can use `(Contolled(X))([control1;control2], target) statement`.
+


### PR DESCRIPTION
Some examples have been added to TypeModel.Controlled section, they demonstrate Controlled statement with some control qubits.

It allows user to copy-paste an example without looking for array declaration syntax.