### PR TITLE
chore: Replace ~ images with relative links for GH

### DIFF
--- a/articles/concepts/circuits.md
+++ b/articles/concepts/circuits.md
@@ -17,7 +17,7 @@ Operations with this or greater complexity are ubiquitous in quantum algorithms 
 
 <!--- ![](.\media\1.svg) --->
 <!-- Can't find a way to easily center this... probably an extension needed:  -->
-![](~/media/Concepts1.png)
+![](../media/Concepts1.png)
 
 This visual language for quantum operations can be more readily digestible than writing down its equivalent matrix once you understand the conventions for expressing a quantum circuit.  We review these conventions below.
 
@@ -25,7 +25,7 @@ In a circuit diagram, each solid line depicts a qubit or more generally a qubit 
 
 <!--- ![](.\media\2.svg) --->
 <!-- Can't find a way to easily center this... probably an extension needed:  -->
-![](~/media/concepts_2.png)
+![](../media/concepts_2.png)
 
 is the [Hadamard](xref:microsoft.quantum.primitive.h) gate acting on a single-qubit register.
 
@@ -33,7 +33,7 @@ Quantum gates are ordered in chronological order with the left-most gate as the 
 
 <!--- ![](.\media\3.svg) --->
 <!-- Can't find a way to easily center this... probably an extension needed:  -->
-![](~/media/concepts_3.png)
+![](../media/concepts_3.png)
 
 is the unitary matrix $CBA$.  Matrix multiplication obeys the opposite convention: the right-most matrix is applied first. In quantum circuit diagrams, however, the left-most gate is applied first.  This difference can at times lead to confusion, so it is important to note this significant difference between the linear algebraic notation and quantum circuit diagrams.
 
@@ -43,7 +43,7 @@ Multi-qubit circuit diagrams follow similar conventions to single-qubit ones.  A
 
 <!--- ![](.\media\4.svg) --->
 <!-- Can't find a way to easily center this... probably an extension needed:  -->
-![](~/media/concepts_4.png)
+![](../media/concepts_4.png)
 
 We can also view $B$ as having an action on a single two-qubit register rather than two one-qubit registers depending on the context in which the circuit is used. 
 Perhaps the most useful property of such abstract circuit diagrams is that they allow complicated quantum algorithms to be described at a high level without having to compile them down to fundamental gates.  This means that you can get an intuition about the data flow for a large quantum algorithm without needing to understand all the details of how each of the subroutines within the algorithm work.
@@ -52,14 +52,14 @@ The other construct that is built into multi-qubit quantum circuit diagrams is c
 
 <!--- ![](.\media\5.svg) --->
 <!-- Can't find a way to easily center this... probably an extension needed:  -->
-![](~/media/concepts_5.png)
+![](../media/concepts_5.png)
 
 Here the black circle denotes the quantum bit on which the gate is controlled and a vertical wire denotes the unitary that is applied when the control qubit takes the value $1$.
 For the special cases where $G=X$ and $G=Z$ we introduce the following notation to describe the controlled version of the gates (note that the controlled-X gate is the [$CNOT$ gate](xref:microsoft.quantum.primitive.cnot)):
 
 <!--- ![](.\media\6.svg) --->
 <!-- Can't find a way to easily center this... probably an extension needed:  -->
-![](~/media/concepts_6.png)
+![](../media/concepts_6.png)
 
 Q# provides methods to automatically generate the controlled version of an operation, which saves the programmer from having to hand code these operations. An example of this is shown below:
 
@@ -78,7 +78,7 @@ The remaining operation to visualize in circuit diagrams is measurement.  Measur
 
 <!--- ![](.\media\7.svg) ---->
 <!-- Can't find a way to easily center this... probably an extension needed:  -->
-![Measurement circuit](~/media/concepts_7.png)
+![Measurement circuit](../media/concepts_7.png)
 
 Q# implements a [Measure operator](xref:microsoft.quantum.primitive.measure) for this purpose. See the section on <xref:microsoft.quantum.libraries.prelude#measurements> for more information.
 
@@ -86,11 +86,11 @@ Similarly, the subcircuit
 
 <!--- ![](.\media\8.svg) --->
 <!-- Can't find a way to easily center this... probably an extension needed:  -->
-![](~/media/concepts_8.png)
+![](../media/concepts_8.png)
 
 gives a classically controlled gate, where $G$ is applied conditioned on the classical control bit being value $1$.
 
 [Quantum Teleportation](xref:microsoft.quantum.techniques.puttingittogether) is perhaps the best quantum algorithm for illustrating these components. Quantum teleportation is a method for moving data within a quantum computer (or even between distant quantum computers in a quantum network) through the use of entanglement and measurement. Interestingly, it is actually capable of moving a quantum state, say the value in a given qubit, from one qubit to another, without even knowing what the qubit's value is! This is necessary for the protocol to work according to the laws of quantum mechanics.  The quantum teleportation circuit is given below; we also provide an annotated version of the circuit to illustrate how to read the quantum circuit.
 
 <!--- ![](.\media\tp2.svg){ width=50% } --->
-![](~/media/concepts_tp2.png)
+![](../media/concepts_tp2.png)

--- a/articles/concepts/software-stack.md
+++ b/articles/concepts/software-stack.md
@@ -19,7 +19,7 @@ Error correction requires a fast and reliable classical computer to be run in co
 
 A conceptual stack that illustrates the functional flow of factoring 8704143553785700723 in a quantum computing environment is shown below:
 
-![Software stack](~/media/concepts_stack.png)
+![Software stack](../media/concepts_stack.png)
 
 There are several broad stages of programming such a quantum computation.  The first, and arguably most challenging phase, is specifying the problem that one wishes to solve.  In this case, the problem is to factor the number 8704143553785700723  into a product of two prime numbers.  The next step involves designing an algorithm for solving this computational problem.  In this case, Shor's famous quantum factoring algorithm can be used to find the factors.  This algorithm is expressed in Q# and then a sequence of quantum operations is output that could be run on an idealized error-free quantum computer.  
 

--- a/articles/concepts/the-qubit.md
+++ b/articles/concepts/the-qubit.md
@@ -43,7 +43,7 @@ A final important property of measurement is that it does not necessarily damage
 Qubits may also be pictured in $3$D using the [*Bloch sphere*](https://en.wikipedia.org/wiki/Bloch_sphere) representation.  The Bloch sphere gives a way of describing a single-qubit quantum state (which is a two-dimensional complex vector) as a three-dimensional real-valued vector.  This is important because it allows us to visualize single-qubit states and thereby develop reasoning that can be invaluable in understanding multi-qubit states (where sadly the Bloch sphere representation breaks down).  The Bloch sphere can be visualized as follows:
 
 <!--- ![](.\media\bloch.svg){ width=50% } --->
-![Bloch sphere](~/media/concepts_bloch.png)
+![Bloch sphere](../media/concepts_bloch.png)
 
 The arrows in this diagram show the direction in which the quantum state vector is pointing and each transformation of the arrow can be thought of as a rotation about one of the cardinal axes.
 While thinking about a quantum computation as a sequence of rotations is a powerful intuition, it is challenging to use this intuition to design and describe algorithms. Q# alleviates this issue by providing a language for describing such rotations.

--- a/articles/libraries/chemistry/installation.md
+++ b/articles/libraries/chemistry/installation.md
@@ -16,25 +16,25 @@ As with other NuGet packages, it's straightforward to add the chemistry library 
 **Visual Studio 2017:** If you are using Visual Studio 2017, you can add the quantum chemistry packages by using the NuGet Package Manager.
 To open the Package Manager, right-click on the project you'd like to add the chemistry library to and select "Manage NuGet Packages...," as in the screenshot below.
 
-![](~/media/vs2017-nuget-manage-packages.png)
+![](../../media/vs2017-nuget-manage-packages.png)
 
 From the Browse tab, search for the package name "Microsoft.Quantum.Chemistry."
 
 > [!NOTE]
 > Make sure to tick "Include prerelease."
 
-![](~/media/vs2017-nuget-package-search.png)
+![](../../media/vs2017-nuget-package-search.png)
 
 This will list the packages available for download.
 Click on the "Microsoft.Quantum.Chemistry on the left-hand pane, select the latest pre-release version on the right-hand pane, and click "Install":
 
-![](~/media/vs2017-nuget-select-chem.png)
+![](../../media/vs2017-nuget-select-chem.png)
 
 For more details, see the [Package Manager UI guide](https://docs.microsoft.com/en-us/nuget/tools/package-manager-ui).
 
 Alternatively, you can use the Package Manager Console to add the quantum chemistry library to your project with a command line interface.
 
-![](~/media/vs2017-nuger-console-menu.png)
+![](../../media/vs2017-nuger-console-menu.png)
 
 From the package manager console, run the following:
 

--- a/articles/libraries/chemistry/schema/broombridge.md
+++ b/articles/libraries/chemistry/schema/broombridge.md
@@ -21,7 +21,7 @@ Being YAML-based, Broombridge is a structured, human-readable and human-editable
 The data format can be generated from NWChem with effortless ease: a variety of methods is available that range from a full installation of NWChem to run chemistry decks such as the ones provided [here](https://github.com/nwchemgit/nwchem/tree/master/QA/chem_library_tests) and output Broombridge as part of the run, over a docker image of NWchem which can also be used to generate Broombridge from chemistry decks. Finally, a visual method to get started with computational chemistry quickly without having to install any chemistry software is provided by the [EMSL Arrows](https://arrows.emsl.pnnl.gov/api/qsharp_chem) interface to NWChem. 
 
 At a high level, the interplay between NWChem and the Microsoft Quantum Development Kit can be visualized as follows: 
-![Chemistry stack](~/media/broombridge.png)
+![Chemistry stack](../../../media/broombridge.png)
 The blue shaded box represents the Broombridge schema, the various grey shaded boxes represent other internal data representations that were chosen to represent and process quantum algorithms for computational chemistry based on real-world chemistry problems. 
 
 Multiple chemical representations defined using the Broombridge schema are provided [here] (https://raw.githubusercontent.com/Microsoft/Quantum/master/Chemistry/IntegralData/YAML/).

--- a/articles/libraries/standard/algorithms.md
+++ b/articles/libraries/standard/algorithms.md
@@ -115,7 +115,7 @@ This expansion can be further simplified by noting that for any integer $j$ and 
 $$\ket{\phi\_k(a+b)}=\frac{1}{\sqrt{2}}\left(\ket{0} + e^{i2\pi [a/2^k+0.b\_k\ldots b\_1]}\ket{1} \right).$$
 This means that if we perform addition by incrementing each of the tensor factors in the expansion of the Fourier transform of $\ket{a}$ then the number of rotations shrinks as $k$ decreases.  This substantially reduces the number of quantum gates needed in the adder.  We denote the Fourier transform, phase addition and the inverse Fourier transform steps that comprise the Draper adder as $\operatorname{QFT}^{-1} \left(\phi\\\!\operatorname{ADD}\right) \operatorname{QFT}$. A quantum circuit that uses this simplification to implement the entire process can be seen below.
 
-![Draper adder shown as circuit diagram](~/media/draper.png)
+![Draper adder shown as circuit diagram](../../media/draper.png)
 
 Each controlled $e^{i2\pi/k}$ gate in the circuit refers to a controlled-phase gate.  Such gates have the property that on the pair of qubits on which they act, $\ket{00}\mapsto \ket{00}$ but $\ket{11}\mapsto e^{i2\pi/k}\ket{11}$.  This circuit allows us to perform addition using no additional qubits apart from those needed to store the inputs and the outputs.
 
@@ -129,7 +129,7 @@ $$
 
 The Beauregard adder uses the Draper adder, or more specifically $\phi\\\!\operatorname{ADD}$, to add $a$ and $b$ in phase.  It then uses the same operation to identify whether $a+b <N$ by subtracting $N$ and testing if $a+b-N<0$.  The circuit stores this information in an ancillary qubit and then adds $N$ back the register if $a+b<N$.  It then concludes by uncomputing this ancillary bit (this step is needed to ensure that the ancilla can be de-allocated after calling the adder).  The circuit for the Beauregard adder is given below.
 
-![Beauregard adder shown as circuit diagram](~/media/beau.png)
+![Beauregard adder shown as circuit diagram](../../media/beau.png)
 
 Here the gate $\Phi\\\!\operatorname{ADD}$ takes the same form as $\phi\\\!\operatorname{ADD}$ except that in this context the input is classical rather than quantum.  This allows the controlled phases in $\Phi\\\!\operatorname{ADD}$ to be replaced with phase gates that can then be compiled together into fewer operations to reduce both the number of qubits and number of gates needed for the adder.
 

--- a/articles/libraries/standard/prelude.md
+++ b/articles/libraries/standard/prelude.md
@@ -80,7 +80,7 @@ It corresponds to the single-qubit unitary:
 
 Below we see these transformations mapped to the [Bloch sphere](xref:microsoft.quantum.concepts.qubit#visualizing-qubits-and-transformations-using-the-bloch-sphere) (the rotation axis in each case is highlighted red):
 
-![Pauli operations mapped onto the Bloch sphere](~/media/prelude_pauliBloch.png)
+![Pauli operations mapped onto the Bloch sphere](../../media/prelude_pauliBloch.png)
 
 It is important to note that applying the same Pauli gate twice to the same qubit cancels out the operation (because you have now performed a full rotation of 2π (360°) over the surface to the Bloch Sphere, thus arriving back at the starting point). This brings us to the following identity:
 
@@ -90,7 +90,7 @@ $$
 
 This can be visualised on the Bloch sphere:
 
-![XX = I](~/media/prelude_blochIdentity.png)
+![XX = I](../../media/prelude_blochIdentity.png)
 
 #### Other Single-Qubit Cliffords ####
 
@@ -109,7 +109,7 @@ and corresponds to the single-qubit unitary:
 
 The Hadamard gate is particularly important as it can be used to create a superposition of the $\ket{0}$ and $\ket{1}$ states. In the Bloch sphere representation, it is easiest to think of this as a rotation of $\ket{\psi}$ around the x-axis by $\pi$ radians ($180^\circ$) followed by a (clockwise) rotation around the y-axis by $\pi/2$ radians ($90^\circ$):
 
-![Hadamard operation mapped onto the Bloch sphere](~/media/prelude_hadamardBloch.png)
+![Hadamard operation mapped onto the Bloch sphere](../../media/prelude_hadamardBloch.png)
 
 The <xref:microsoft.quantum.primitive.s> operation implements the phase gate $S$.
 This is the matrix square root of the Pauli $Z$ operation.
@@ -195,7 +195,7 @@ It has signature `((Int,Int, Qubit) => Unit : Adjoint, Controlled)`.
 
 An example of a rotation operation (around the Pauli $Z$ axis, in this instance) mapped onto the Bloch sphere is shown below:
 
-![Rotation operation mapped onto the Bloch sphere](~/media/prelude_rotationBloch.png)
+![Rotation operation mapped onto the Bloch sphere](../../media/prelude_rotationBloch.png)
 
 #### Multi-Qubit Operations ####
 

--- a/articles/techniques/putting-it-all-together.md
+++ b/articles/techniques/putting-it-all-together.md
@@ -122,13 +122,13 @@ Shown below is a text-book quantum circuit that implements the teleportation. Mo
 - Step 3: Taking a measurement of the first and second qubits, __message__ and __here__.
 - Step 4: Applying a NOT gate or a Z gate, depending on the result of the measurement in step 3.
 
-![`Teleport(msg : Qubit, there : Qubit) : Unit`](~/media/teleportation.svg)
+![`Teleport(msg : Qubit, there : Qubit) : Unit`](../media/teleportation.svg)
 
 ## Quantum Teleportation: Code
 
 We have our circuit for quantum teleportation:
 
-![`Teleport(msg : Qubit, there : Qubit) : Unit`](~/media/teleportation.svg)
+![`Teleport(msg : Qubit, there : Qubit) : Unit`](../media/teleportation.svg)
 
 We can now translate each of the steps in this quantum circuit into Q#.
 

--- a/articles/techniques/testing-and-debugging.md
+++ b/articles/techniques/testing-and-debugging.md
@@ -156,7 +156,7 @@ using (var sim = new QuantumSimulator())
 
 After you execute a test in Test Explorer and click on the test, a panel will appear with information about test execution: Passed/Failed status, elapsed time and an "Output" link. If you click the "Output" link, test output will open in a new window.
 
-![test output](~/media/unit-test-output.png)
+![test output](../media/unit-test-output.png)
 
 #### [Command Line / Visual Studio Code](#tab/tabid-vscode)
 
@@ -236,7 +236,7 @@ Notice how the ids of the qubits are shown at the top in their significant order
   > [!TIP]
   > You can figure out a qubit id in Visual Studio by putting a breakpoint in your code and inspecting the value of a qubit variable, for example:
   > 
-  > ![show qubit id in Visual Studio](~/media/qubit_id.png)
+  > ![show qubit id in Visual Studio](../media/qubit_id.png)
   >
   > the qubit with index `0` on `register2` has id=`3`, the qubit with index `1` has id=`2`.
 


### PR DESCRIPTION
These links are OK for DocFx, but GitHub doesn't like them. Should get ride of some build warnings too.