### PR TITLE
Adding searchScope

### DIFF
--- a/api/docfx.json
+++ b/api/docfx.json
@@ -48,7 +48,8 @@
         "variance": "\\operatorname{Var}",
         "defeq": "\\mathrel{:=}"
       },
-      "ms.devlang":"qsharp"
+      "ms.devlang":"qsharp",
+      "searchScope": ["quantum", "q#", "qsharp"]
     },
     "fileMetadata": {},
     "template": [],

--- a/articles/docfx.json
+++ b/articles/docfx.json
@@ -41,7 +41,8 @@
     "externalReference": [],
     "globalMetadata": {
       "show_latex": true,
-      "ms.prod": "quantum"
+      "ms.prod": "quantum",
+      "searchScope": ["quantum", "q#", "qsharp"]
     },
     "fileMetadata": {
       "latex_macros": {


### PR DESCRIPTION
Adding search scope to enable search for quantum docs on docs.microsoft.com