### PR TITLE
Missing $ for inline equation on ContinuousOracle type

### DIFF
--- a/api/canon/microsoft.quantum.canon.continuousoracle.yml
+++ b/api/canon/microsoft.quantum.canon.continuousoracle.yml
@@ -5,7 +5,7 @@ type: newtype
 namespace: Microsoft.Quantum.Canon
 summary: >-
   Represents a continuous-time oracle
-  $U(\delta t) : \ket{\psi(t)} \mapsto \ket{\psi(t + \delta t)}
+  $U(\delta t) : \ket{\psi(t)} \mapsto \ket{\psi(t + \delta t)}$
   for all times $t$, where $U$ is a fixed operation, and where
   and $\delta t$ is a non-negative real number.
 syntax: 'newtype ContinuousOracle = ((Double, Qubit[]) => Unit : Adjoint, Controlled);'


### PR DESCRIPTION
The documentation for the ContinuousOracle type (https://docs.microsoft.com/en-us/qsharp/api/canon/microsoft.quantum.canon.continuousoracle?view=qsharp-preview) has a missing $ symbol to close the inline equation. This change is modified in QuantumLibraries as well as here.