### PR TITLE
Escape pipe character inside expressions table

### DIFF
--- a/articles/language/expressions.md
+++ b/articles/language/expressions.md
@@ -574,6 +574,6 @@ Operator | Arity | Description | Operand Types
  `==`, `!=` | Binary | equal, not-equal comparisons | any primitive type
  `&&&` | Binary | Bitwise AND | `Int`
  `^^^` | Binary | Bitwise XOR | `Int`
- `\\|\\|\\|` | Binary | Bitwise OR | `Int`
+ <code>\|\|\|</code> | Binary | Bitwise OR | `Int`
  `&&` | Binary | Logical AND | `Bool`
- `\\|\\|` | Binary | Logical OR | `Bool`
+ <code>\|\|</code> | Binary | Logical OR | `Bool`

--- a/articles/language/expressions.md
+++ b/articles/language/expressions.md
@@ -574,6 +574,6 @@ Operator | Arity | Description | Operand Types
  `==`, `!=` | Binary | equal, not-equal comparisons | any primitive type
  `&&&` | Binary | Bitwise AND | `Int`
  `^^^` | Binary | Bitwise XOR | `Int`
- `\|\|\|` | Binary | Bitwise OR | `Int`
+ `\\|\\|\\|` | Binary | Bitwise OR | `Int`
  `&&` | Binary | Logical AND | `Bool`
- `\|\|` | Binary | Logical OR | `Bool`
+ `\\|\\|` | Binary | Logical OR | `Bool`

--- a/articles/language/expressions.md
+++ b/articles/language/expressions.md
@@ -574,6 +574,6 @@ Operator | Arity | Description | Operand Types
  `==`, `!=` | Binary | equal, not-equal comparisons | any primitive type
  `&&&` | Binary | Bitwise AND | `Int`
  `^^^` | Binary | Bitwise XOR | `Int`
- `|||` | Binary | Bitwise OR | `Int`
+ `\|\|\|` | Binary | Bitwise OR | `Int`
  `&&` | Binary | Logical AND | `Bool`
- `||` | Binary | Logical OR | `Bool`
+ `\|\|` | Binary | Logical OR | `Bool`


### PR DESCRIPTION
Broken in 0.3 release, returning to the syntax used before that.