### PR TITLE
Removing version number from install instructions.

### DIFF
--- a/articles/install-guide/command-line.md
+++ b/articles/install-guide/command-line.md
@@ -17,7 +17,7 @@ The Quantum Development Kit uses the .NET Core SDK (2.0 or later) to make it eas
 
 2. Once the .NET Core SDK is installed, run the following command in your favorite command line (e.g.: PowerShell or Bash) to download the latest templates for creating new Q# applications and libraries:
    ```Bash
-   dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.3.1811.2802-preview"
+   dotnet new -i Microsoft.Quantum.ProjectTemplates
    ```
 
 You should now have the Quantum Development Kit installed and ready to use in your own applications and libraries.

--- a/articles/install-guide/vs-code.md
+++ b/articles/install-guide/vs-code.md
@@ -18,7 +18,7 @@ We recommend using the Quantum Development Kit together with Visual Studio Code 
 
 2. Once the .NET Core SDK is installed, run the following command in your favorite command line (e.g.: PowerShell or Bash) to download the latest templates for creating new Q# applications and libraries:
    ```Bash
-   dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.3.1811.2802-preview"
+   dotnet new -i Microsoft.Quantum.ProjectTemplates
    ```
 
 3. Go to the [Visual Studio Code website](https://code.visualstudio.com/).


### PR DESCRIPTION
Removing version number from instructions on how to install project templates. Now it will automatically pick latest