### PR TITLE
Fix operator ordering to conform with theory

### DIFF
--- a/articles/techniques/putting-it-all-together.md
+++ b/articles/techniques/putting-it-all-together.md
@@ -167,8 +167,8 @@ Finally, we use @"microsoft.quantum.primitive.m" to perform the measurements and
 
 ```qsharp
             // Measure out the entanglement
-            if (M(msg) == One)  { Z(there); }
             if (M(here) == One) { X(there); }
+            if (M(msg) == One)  { Z(there); }
 ```
 
 This finishes the definition of our teleportation operator, so we can deallocate `here`, end the body, and end the operation.


### PR DESCRIPTION
The quantum circuit diagram, as well as the description, specify the order of (optional) quantum gates as `X`, then `Z`. The attached `Q#` snippet gave the wrong order.