### PR TITLE
Add Diagnostics article to table of contents

### DIFF
--- a/articles/libraries/standard/toc.yml
+++ b/articles/libraries/standard/toc.yml
@@ -18,3 +18,5 @@
   href: error-correction.md
 - name: Applications
   href: applications.md
+- name: Testing and Diagnostics
+  href: diagnostics.md


### PR DESCRIPTION
This link was lost in the 0.6 release as part of some branch conflict. It used to be the last item on the list, so I added it there.