### PR TITLE
fix version for images

### DIFF
--- a/articles/docfx.json
+++ b/articles/docfx.json
@@ -29,7 +29,8 @@
         "exclude": [
           "**/obj/**",
           "**/includes/**"
-        ]
+        ],
+        "version": "qsharp-preview"
       }
     ],
     "versions": {


### PR DESCRIPTION
This is to avoid "false alarm" of warnings on missing images (example: https://github.com/MicrosoftDocs/quantum-docs-pr/pull/493).