### PR TITLE
Updated TOC for accurate titles in sidebar dropdowns

### DIFF
--- a/articles/TOC.yml
+++ b/articles/TOC.yml
@@ -4,12 +4,10 @@
   topicHref: install-guide/index.md
   href: install-guide/toc.yml
 - name: Quantum computing concepts
-  topicHref: concepts/index.md
   href: concepts/toc.yml
 - name: Quickstart - your first quantum program
   href: quickstart.md
 - name: Managing quantum machines and drivers
-  topicHref: machines/index.md
   href: machines/toc.yml
 - name: Quantum development techniques
   topicHref: techniques/index.md

--- a/articles/concepts/toc.yml
+++ b/articles/concepts/toc.yml
@@ -1,3 +1,5 @@
+- name: What is quantum computing?
+  href: index.md
 - name: Vectors and matrices
   href: vectors-and-matrices.md
 - name: Advanced matrix concepts

--- a/articles/machines/toc.yml
+++ b/articles/machines/toc.yml
@@ -1,3 +1,5 @@
+- name: Classical machines and drivers
+  href: index.md
 - name: Quantum simulator
   href: full-state-simulator.md
 - name: Resources estimator


### PR DESCRIPTION
(This may be irrelevant and taken care of in the impending overhaul--disregard if so. It was such a quick fix I figured I might as well.)

With each subsection's index.md file as a topicHref in TOC.yml, the first page in each dropdown was simply inheriting the section's name. Besides looking odd, it also made those dropdown titles inconsistent with the page to which they led. Only changed the two most glaring sections:
* Quantum computing concepts
* Managing quantum machines and drivers
