### PR TITLE
Fix OPS build warnings

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -8,7 +8,7 @@
       "monikers": [],
       "moniker_ranges": [],
       "xref_query_tags": [
-        "/qsharp"
+        "/quantum"
       ],
       "enable_xrefmap_share": true,
       "open_to_public_contributors": false,

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -34,39 +34,6 @@
       ]
     },
     {
-      "docset_name": "quantum-api-private",
-      "build_source_folder": "api",
-      "build_output_subfolder": "quantum-api-private",
-      "locale": "en-us",
-      "monikers": [],
-      "moniker_ranges": [],
-      "xref_query_tags": [
-        "/qsharp"
-      ],
-      "enable_xrefmap_share": true,
-      "open_to_public_contributors": false,
-      "type_mapping": {
-        "Conceptual": "Content",
-        "QSharpNamespace": "Content",
-        "QSharpType": "Content"
-      },
-      "build_entry_point": "docs",
-      "template_folder": "_themes",
-      "customized_tasks": {
-        "docset_prebuild": [
-          "_dependentPackages/CommonPlugins/tools/JoinTOC.ps1"
-        ]
-      },
-      "JoinTOCPlugin": [
-        {
-          "ReferenceTOC": "api/TOC.yml",
-          "ConceptualTOC": "articles/TOC.yml",
-          "ReferenceTOCUrl": "/qsharp/api/toc.json",
-          "ConceptualTOCUrl": "/quantum/toc.json"
-        }
-      ]
-    },
-    {
       "docset_name": "quantum-docs",
       "build_source_folder": "articles",
       "build_output_subfolder": "quantum-docs",
@@ -76,26 +43,6 @@
       "xref_query_tags": [
         "/qsharp",
         "/dotnet"
-      ],
-      "enable_xrefmap_share": true,
-      "open_to_public_contributors": false,
-      "type_mapping": {
-        "Conceptual": "Content",
-        "ManagedReference": "Content",
-        "Odata": "Content"
-      },
-      "build_entry_point": "docs",
-      "template_folder": "_themes"
-    },
-    {
-      "docset_name": "quantum-docs-private",
-      "build_source_folder": "articles",
-      "build_output_subfolder": "quantum-docs-private",
-      "locale": "en-us",
-      "monikers": [],
-      "moniker_ranges": [],
-      "xref_query_tags": [
-        "/qsharp"
       ],
       "enable_xrefmap_share": true,
       "open_to_public_contributors": false,

--- a/articles/contributing/style-guide.md
+++ b/articles/contributing/style-guide.md
@@ -208,6 +208,12 @@ We suggest:
 
 ***
 
+### Private or Internal Names ###
+
+In many cases, a name is intended strictly for use internal to a library or project, and is not a guaranteed part of the API offered by a library.
+It is helpful to clearly indicate that this is the case when naming functions and operations so that accidental dependencies on internal-only code are made obvious.
+If an operation or function is not intended for direct use, but rather should be used by a matching callable which acts by partial application, consider using a name starting with `_` for the callable that is partially applied.
+
 # [Guidance](#tab/guidance)
 
 We suggest:

--- a/articles/contributing/style-guide.md
+++ b/articles/contributing/style-guide.md
@@ -208,19 +208,6 @@ We suggest:
 
 ***
 
-### Private or Internal Names ###
-
-In many cases, a name is intended strictly for use internal to a library or project, and is not a guaranteed part of the API offered by a library.
-It is helpful to clearly indicate that this is the case when naming functions and operations so that accidental dependencies on internal-only code are made obvious.
-If an operation or function is not intended for direct use, but rather should be used by a matching callable which acts by partial application, consider using a name starting with `_` for the callable that is partially applied, and marking the function or operation as private with the <xref:microsoft.quantum.core.private> attribute:
-
-```Q#
-@Private()
-operation _ApplyDecomposedOperation(decomposition : Int[], targets : Qubit[]) : Unit {
-    // ...
-}
-```
-
 # [Guidance](#tab/guidance)
 
 We suggest:

--- a/articles/libraries/chemistry/concepts/algorithms.md
+++ b/articles/libraries/chemistry/concepts/algorithms.md
@@ -197,7 +197,7 @@ which again can be seen to implement an operator that is equivalent (up to an is
 
 These subroutines are easy to set up in Q#.
 As an example, consider the simple qubit transverse-Ising Hamiltonian where $H = X_1 + X_2 + Z_1 Z_2$.
-In this case, Q# code that would implement the $\operatorname{Select}$ operation is invoked by <xref:microsoft.quantum.canon.multiplexoperations>, whereas the $\operatorname{Prepare}$ operation can be implemented using <xref:microsoft.quantum.canon.preparearbitrarystate>.
+In this case, Q# code that would implement the $\operatorname{Select}$ operation is invoked by <xref:microsoft.quantum.canon.multiplexoperations>, whereas the $\operatorname{Prepare}$ operation can be implemented using <xref:microsoft.quantum.preparation.preparearbitrarystate>.
 An example that involves simulating the Hubbard model can be found as a [Q# sample](https://github.com/Microsoft/Quantum/tree/master/Samples/src/HubbardSimulation).
 
 Manually specifying these steps for arbitrary chemistry problems would require much effort, which is avoided using the chemistry library.

--- a/articles/libraries/chemistry/concepts/second-quantization.md
+++ b/articles/libraries/chemistry/concepts/second-quantization.md
@@ -105,7 +105,7 @@ a^\dagger_1 \ket{0}_1 = \ket{1}_1,\quad a^\dagger_1 \ket{1}_1 = 0,\quad a_1 \ket
 \end{align}
 Note that here $a^\dagger_1 \ket{1}_1=0$ and $a_1 \ket{0}_1$ yield the zero-vector not $\ket{0}_1$.
 Such operators are therefore neither Hermitian nor unitary.
-We represent general creation and annihilation operators using the <xref:Microsoft.Quantum.Chemistry.LadderOperators.LadderOperator> type.
+We represent general creation and annihilation operators using the <xref:Microsoft.Quantum.Chemistry.LadderOperators.LadderOperator`1> type.
 For instance, a single creation operator is represented as follow.
 
 ```csharp
@@ -199,7 +199,7 @@ Such operators are said to 'anti-commute' and in general for any $i, j$ we have 
 \begin{align}
 a^\dagger_i a^\dagger_j  = -(1-\delta_{i,j})a^\dagger_j a^\dagger_i,\quad a^\dagger_i a_j =\delta_{i,j} - a_j a^\dagger_i.
 \end{align}
-Thus the following two <xref:Microsoft.Quantum.Chemistry.LadderOperators.LadderSequence> instances are considered inequivalent
+Thus the following two <xref:Microsoft.Quantum.Chemistry.LadderOperators.LadderSequence`1> instances are considered inequivalent
 ```csharp
     // Let us initialize an array of tuples representing the
     // desired sequence of creation operators.

--- a/articles/libraries/standard/prelude.md
+++ b/articles/libraries/standard/prelude.md
@@ -277,7 +277,7 @@ First, since performing single-qubit measurements is quite common, the prelude d
 The <xref:microsoft.quantum.intrinsic.m> operation measures the Pauli $Z$ operator on a single qubit, and has signature `(Qubit => Result)`.
 `M(q)` is equivalent to `Measure([PauliZ], [q])`.
 
-The <xref:microsoft.quantum.canon.multim> measures the Pauli $Z$ operator *separately* on each of an array of qubits, returning the *array* of `Result` values obtained for each qubit.
+The <xref:microsoft.quantum.measurement.multim> measures the Pauli $Z$ operator *separately* on each of an array of qubits, returning the *array* of `Result` values obtained for each qubit.
 In some cases this can be optimized. 
 It has signature (`Qubit[] => Result[])`.
 `MultiM(qs)` is equivalent to:

--- a/articles/techniques/index.md
+++ b/articles/techniques/index.md
@@ -4,14 +4,16 @@ description: Quantum development techniques
 keywords: Don’t add or edit keywords without consulting your SEO champ.
 author: QuantumWriter
 ms.author: MSFT-alias-person-or-DL
-ms.date: 10/09/2017
+ms.date: 9/20/2019
 ms.topic: article-type-from-white-list
 uid: microsoft.quantum.techniques.intro
 ---
 
-<img src="media/mobius_strip_preview.png" style="float: right;" title="Quantum" alt="Quantum">
 
 # Quantum Development Techniques
+
+![Quantum](~/media/mobius_strip_preview.png)
+
 This section details the core concepts used to create quantum programs in Q#, and to interact with those programs from classical .NET applications.
 This section assumes some knowledge of quantum computing concepts like those described in [Quantum computing concepts](xref:microsoft.quantum.concepts.intro).
 


### PR DESCRIPTION
- Remove private docset configs (these do not exist)
- Temporarily remove attribute example in the style guide (see #524)
- Update xrefs
- Fix xref_query_tags in the API docset, so that UIDs in the articles docset are resolved
