### PR TITLE
Add python library reference to the TOC

### DIFF
--- a/api/toc.yml
+++ b/api/toc.yml
@@ -1,8 +1,10 @@
 - name: Q# library reference
   href: qsharp/toc.yml
-- name: C# components reference
+- name: C# libraries
   items:
   - name: Trace simulator 
     href: https://docs.microsoft.com/dotnet/api/microsoft.quantum.simulation.simulators.qctracesimulators
   - name: Quantum chemistry
     href: https://docs.microsoft.com/dotnet/api/microsoft.quantum.chemistry
+- name: Python libraries
+  href: https://docs.microsoft.com/python/qsharp    


### PR DESCRIPTION
Add link to Python library reference docs.

The embedded TOC changes will be added in a subsequent PR.