### PR TITLE
Fix broken link to 5-qubit perfect ECC

### DIFF
--- a/articles/libraries/standard/error-correction.md
+++ b/articles/libraries/standard/error-correction.md
@@ -129,4 +129,4 @@ using (scratch = Qubit[nScratch]) {
 
 We explore this in more detail in the [bit flip code sample](https://github.com/Microsoft/Quantum/tree/master/Samples/src/BitFlipCode).
 
-Aside from the bit-flip code, the Q# canon is provided with implementations of the [five-qubit perfect code](https://arxiv.org/abs/1305.08), and the [seven-qubit code](https://arxiv.org/abs/quant-ph/9705052), both of which can correct an arbitrary single-qubit error.
+Aside from the bit-flip code, the Q# canon is provided with implementations of the [five-qubit perfect code](https://arxiv.org/abs/quant-ph/9602019), and the [seven-qubit code](https://arxiv.org/abs/quant-ph/9705052), both of which can correct an arbitrary single-qubit error.


### PR DESCRIPTION
Let's try fixing #477 once more... The link to the paper is taken from our docs at https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.errorcorrection.fivequbitcode