### PR TITLE
Fix VS Code instructions in "Create a Q# Project"

### DIFF
--- a/articles/how-to-guides/create-qsharp-project.md
+++ b/articles/how-to-guides/create-qsharp-project.md
@@ -145,6 +145,7 @@ You can now continue your quantum development using Visual Studio
 
     * Go to **View** -> **Command Palette**
     * Select **Q#: Create New Project**
+	* Select **Standalone console application**
     * Navigate to the location on the file system where you would like to create the application
     * Click on the **Open new project...** button, once the project has been created
 

--- a/articles/how-to-guides/create-qsharp-project.md
+++ b/articles/how-to-guides/create-qsharp-project.md
@@ -151,7 +151,8 @@ You can now continue your quantum development using Visual Studio
 
 1. Run the application:
 
-    * Go to **Debug** -> **Start Without Debugging**
+    * Go to **Terminal** -> **New Terminal**
+	* Enter `dotnet run`
     * You should see the following text in the output window `Hello quantum world!`
 
 You can now continue your quantum development using Visual Studio Code.


### PR DESCRIPTION
Applies the change to the "Create a Q# Project" page. The new instructions are also included in Eduardo and I's PRs on the update/install pages (#615 and #616).

This is the only part of #611 not superseded by those two, so I will be closing #611 now