### PR TITLE
Fix LaTeX rendering and feedback link.

### DIFF
--- a/api/docfx.json
+++ b/api/docfx.json
@@ -39,25 +39,31 @@
     "overwrite": [],
     "externalReference": [],
     "globalMetadata": {
-      "latex_macros": {
-        "ket": ["\\left| #1\\right\\rangle", 1],
-        "bra": ["\\left\\langle #1\\right|", 1],
-        "braket": ["\\left\\langle #1 \\right\\rangle", 1],
-        "boldone": "\\mathbf{1}",
-        "expect": "\\mathbb{E}",
-        "variance": "\\operatorname{Var}",
-        "defeq": "\\mathrel{:=}"
-      },
+      "show_latex": true,
       "ms.prod": "quantum",
       "ms.topic": "managed-reference",
       "ms.devlang":"qsharp",
       "searchScope": ["quantum", "q#", "qsharp"],
       "feedback_system": "GitHub",
-      "feedback_github_repo": "Microsoft/quantum",
-      "feedback_product_url": "https://github.com/microsoft/quantum/issues",
+      "feedback_github_repo": "Microsoft/quantumlibraries",
+      "feedback_product_url": "https://github.com/microsoft/quantumlibraries/issues",
       "titleSuffix": "Q# reference - Microsoft Quantum"
     },
-    "fileMetadata": {},
+    "fileMetadata": {
+      "latex_macros": {
+        "**/**.md": {
+          "ket": ["\\left| #1\\right\\rangle", 1],
+          "bra": ["\\left\\langle #1\\right|", 1],
+          "braket": [ "\\left\\langle #1 \\right\\rangle", 1 ],
+          "id": "\\mathbb{1}",
+          "boldone": "\\mathbf{1}",
+          "expect": "\\mathbb{E}",
+          "variance": "\\operatorname{Var}",
+          "defeq": "\\mathrel{:=}",
+          "dd": "\\mathrm{d}"
+        }
+      }
+    },
     "template": [],
     "dest": "quantum-api"
   }

--- a/api/docfx.json
+++ b/api/docfx.json
@@ -40,17 +40,6 @@
     "externalReference": [],
     "globalMetadata": {
       "show_latex": true,
-      "latex_macros": {
-        "ket": ["\\left| #1\\right\\rangle", 1],
-        "bra": ["\\left\\langle #1\\right|", 1],
-        "braket": [ "\\left\\langle #1 \\right\\rangle", 1 ],
-        "id": "\\mathbb{1}",
-        "boldone": "\\mathbf{1}",
-        "expect": "\\mathbb{E}",
-        "variance": "\\operatorname{Var}",
-        "defeq": "\\mathrel{:=}",
-        "dd": "\\mathrm{d}"
-      },
       "ms.prod": "quantum",
       "ms.topic": "managed-reference",
       "ms.devlang":"qsharp",
@@ -60,7 +49,21 @@
       "feedback_product_url": "https://github.com/microsoft/quantumlibraries/issues",
       "titleSuffix": "Q# reference - Microsoft Quantum"
     },
-    "fileMetadata": {},
+    "fileMetadata": {
+      "latex_macros": {
+        "**/*.*": {
+          "ket": ["\\left| #1\\right\\rangle", 1],
+          "bra": ["\\left\\langle #1\\right|", 1],
+          "braket": [ "\\left\\langle #1 \\right\\rangle", 1 ],
+          "id": "\\mathbb{1}",
+          "boldone": "\\mathbf{1}",
+          "expect": "\\mathbb{E}",
+          "variance": "\\operatorname{Var}",
+          "defeq": "\\mathrel{:=}",
+          "dd": "\\mathrm{d}"
+        }
+      }
+    },
     "template": [],
     "dest": "quantum-api"
   }

--- a/api/docfx.json
+++ b/api/docfx.json
@@ -40,6 +40,17 @@
     "externalReference": [],
     "globalMetadata": {
       "show_latex": true,
+      "latex_macros": {
+        "ket": ["\\left| #1\\right\\rangle", 1],
+        "bra": ["\\left\\langle #1\\right|", 1],
+        "braket": [ "\\left\\langle #1 \\right\\rangle", 1 ],
+        "id": "\\mathbb{1}",
+        "boldone": "\\mathbf{1}",
+        "expect": "\\mathbb{E}",
+        "variance": "\\operatorname{Var}",
+        "defeq": "\\mathrel{:=}",
+        "dd": "\\mathrm{d}"
+      },
       "ms.prod": "quantum",
       "ms.topic": "managed-reference",
       "ms.devlang":"qsharp",
@@ -49,21 +60,7 @@
       "feedback_product_url": "https://github.com/microsoft/quantumlibraries/issues",
       "titleSuffix": "Q# reference - Microsoft Quantum"
     },
-    "fileMetadata": {
-      "latex_macros": {
-        "**/**.yml": {
-          "ket": ["\\left| #1\\right\\rangle", 1],
-          "bra": ["\\left\\langle #1\\right|", 1],
-          "braket": [ "\\left\\langle #1 \\right\\rangle", 1 ],
-          "id": "\\mathbb{1}",
-          "boldone": "\\mathbf{1}",
-          "expect": "\\mathbb{E}",
-          "variance": "\\operatorname{Var}",
-          "defeq": "\\mathrel{:=}",
-          "dd": "\\mathrm{d}"
-        }
-      }
-    },
+    "fileMetadata": {},
     "template": [],
     "dest": "quantum-api"
   }

--- a/api/docfx.json
+++ b/api/docfx.json
@@ -51,7 +51,7 @@
     },
     "fileMetadata": {
       "latex_macros": {
-        "**/**.md": {
+        "**/**.yml": {
           "ket": ["\\left| #1\\right\\rangle", 1],
           "bra": ["\\left\\langle #1\\right|", 1],
           "braket": [ "\\left\\langle #1 \\right\\rangle", 1 ],


### PR DESCRIPTION
This PR moves LaTeX macros from global to file metadata to fix microsoft/Quantum#271, and redirects feedback for Q# API references to the libraries repo that's used to generate those references.