### PR TITLE
"Quantum Development Techniques" section overview page

### DIFF
--- a/articles/techniques/file-structure.md
+++ b/articles/techniques/file-structure.md
@@ -1,11 +1,12 @@
 ---
 # Mandatory fields. See more on aka.ms/skyeye/meta.
-title: Quantum development techniques introduction | Microsoft Docs 
-description: Quantum development techniques introduction
+title: Q# program overview - Q# techniques | Microsoft Docs 
+description: Q# program overview - Q# techniques
 author: QuantumWriter
 ms.author: Christopher.Granade@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
+uid: microsoft.quantum.techniques.file-structure
 # Use only one of the following. Use ms.service for services, ms.prod for on-prem. Remove the # before the relevant field.
 # For Quantum products none of these categories have been defined  yet.
 # ms.service: service-name-from-white-list

--- a/articles/techniques/going-further.md
+++ b/articles/techniques/going-further.md
@@ -1,11 +1,12 @@
 ---
 # Mandatory fields. See more on aka.ms/skyeye/meta.
-title: Q# techniques - going further | Microsoft Docs
-description: Q# techniques - going further
+title: Going further - Q# techniques | Microsoft Docs
+description: Going further - Q# techniques
 author: QuantumWriter
 ms.author: Christopher.Granade@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
+uid: microsoft.quantum.techniques.going-further
 # Use only one of the following. Use ms.service for services, ms.prod for on-prem. Remove the # before the relevant field.
 # For Quantum products none of these categories have been defined  yet.
 # ms.service: service-name-from-white-list

--- a/articles/techniques/index.md
+++ b/articles/techniques/index.md
@@ -29,7 +29,7 @@ Their contents are as follows.
 	In particular, you will learn the difference between immutable/mutable variables and how to assign/re-assign them.
 
 - [Working with qubits](xref:microsoft.quantum.techniques.qubits) describes the features of Q# that you can use to address individual qubits and systems of qubits. 
-	Specifically, that entails their allocation, or blocking off a certain number of qubits for an operation or program to use; performing operations on them; and ultimately their measurement. 
+	Specifically, that entails their allocation, performing operations on them, and ultimately their measurement. 
 	Additionally, you will learn some useful control flow techniques.
 
 - In [Putting it all together](xref:microsoft.quantum.techniques.puttingittogether), you will leverage the techniques from the sections above to create a program which performs **quantum teleportation**: using two classical bits to "teleport" the full state of one qubit onto another.

--- a/articles/techniques/index.md
+++ b/articles/techniques/index.md
@@ -35,7 +35,7 @@ Their contents are as follows.
 - In [Putting it all together](xref:microsoft.quantum.techniques.puttingittogether), you will leverage the techniques from the sections above to create a program which performs **quantum teleportation**: using two classical bits to "teleport" the full state of one qubit onto another.
 
 - [Going further](xref:microsoft.quantum.techniques.going-further) introduces advanced techniques that can prove helpful as you move toward more complex quantum programming. 
-	In particular, we discuss the use of *generic* operations and functions in Q#, which enable higher-order control flow by remaining agnostic to the specific types of their input/output, as well as *borrowing* qubits. 
+	In particular, we discuss the use of *type-parameterized* operations and functions in Q#, which enable higher-order control flow by remaining agnostic to the specific types of their input/output, as well as *borrowing* qubits. 
 	The latter differs from basic qubit allocation in that a Q# operation may use "dirty" qubits---qubits not necessarily initialized to a known state---to assist computations.
 
 - [Testing and debugging](xref:microsoft.quantum.techniques.testing-and-debugging) details some techniques for making sure your code is doing what it is supposed to. 

--- a/articles/techniques/index.md
+++ b/articles/techniques/index.md
@@ -30,7 +30,7 @@ Their contents are as follows.
 
 - [Working with qubits](xref:microsoft.quantum.techniques.qubits) describes the features of Q# that you can use to address individual qubits and systems of qubits. 
 	Specifically, that entails their allocation, or blocking off a certain number of qubits for an operation or program to use; performing operations on them; and ultimately their measurement. 
-	Additionally, you will learn some useful control-flow techniques.
+	Additionally, you will learn some useful control flow techniques.
 
 - In [Putting it all together](xref:microsoft.quantum.techniques.puttingittogether), you will leverage the techniques from the sections above to create a program which performs **quantum teleportation**: using two classical bits to "teleport" the full state of one qubit onto another.
 

--- a/articles/techniques/index.md
+++ b/articles/techniques/index.md
@@ -12,7 +12,7 @@ uid: microsoft.quantum.techniques.intro
 
 # Quantum Development Techniques
 
-This section of our documentation details the core concepts used to create quantum programs in Q#, and to interact with those programs from classical .NET applications.
+This section of our documentation details the core concepts used to create quantum programs in Q#, and to interact with those programs from classical applications.
 We assume *some* knowledge of quantum computing concepts, like those described in [Quantum computing concepts](xref:microsoft.quantum.concepts.intro), but you needn't be an expert in quantum computing to get a lot from these sections.
 
 Their contents are as follows.
@@ -45,5 +45,4 @@ Their contents are as follows.
 
 
 ![Quantum](~/media/mobius_strip_preview.png)
-
 

--- a/articles/techniques/index.md
+++ b/articles/techniques/index.md
@@ -13,7 +13,7 @@ uid: microsoft.quantum.techniques.intro
 # Quantum Development Techniques
 
 This section of our documentation details the core concepts used to create quantum programs in Q#, and to interact with those programs from classical applications.
-We assume *some* knowledge of quantum computing concepts, like those described in [Quantum computing concepts](xref:microsoft.quantum.concepts.intro), but you needn't be an expert in quantum computing to get a lot from these sections.
+We assume *some* knowledge of quantum computing concepts, like those described in [Quantum computing concepts](xref:microsoft.quantum.concepts.intro), but you need not be an expert in quantum computing to get a lot from these sections.
 
 Their contents are as follows.
 
@@ -45,4 +45,3 @@ Their contents are as follows.
 
 
 ![Quantum](~/media/mobius_strip_preview.png)
-

--- a/articles/techniques/index.md
+++ b/articles/techniques/index.md
@@ -38,7 +38,7 @@ Their contents are as follows.
 	In particular, we discuss the use of *type-parameterized* operations and functions in Q#, which enable higher-order control flow by remaining agnostic to the specific types of their input/output, as well as *borrowing* qubits. 
 	The latter differs from basic qubit allocation in that a Q# operation may use "dirty" qubits---qubits not necessarily initialized to a known state---to assist computations.
 
-- [Testing and debugging](xref:microsoft.quantum.techniques.testing-and-debugging) details some techniques for making sure your code is doing what it is supposed to. 
+- [Testing and debugging](xref:microsoft.quantum.techniques.testing-and-debugging) details some techniques for making sure your code is doing what it is supposed to do. 
 	Due to the general opacity of quantum information, debugging a quantum program can require specialized techniques. 
 	Fortunately, Q# supports many of the classical debugging techniques programmers are used to, as well as those that are quantum-specific. These include creating/running unit tests in Q#, embedding *assertions* on values and probabilities in your code, and the `Dump` functions which output the state of target machine. 
 	The latter can be used alongside our full state simulator to debug certain parts of computations by skirting some quantum limitations (e.g. the no-cloning theorem).

--- a/articles/techniques/index.md
+++ b/articles/techniques/index.md
@@ -13,7 +13,7 @@ uid: microsoft.quantum.techniques.intro
 # Quantum Development Techniques
 
 This section of our documentation details the core concepts used to create quantum programs in Q#, and to interact with those programs from classical .NET applications.
-We assume *some* knowledge of quantum computing concepts like those described in [Quantum computing concepts](xref:microsoft.quantum.concepts.intro), but you needn't be an expert in quantum computing to get a lot from these sections.
+We assume *some* knowledge of quantum computing concepts, like those described in [Quantum computing concepts](xref:microsoft.quantum.concepts.intro), but you needn't be an expert in quantum computing to get a lot from these sections.
 
 Their contents are as follows.
 

--- a/articles/techniques/index.md
+++ b/articles/techniques/index.md
@@ -15,21 +15,33 @@ uid: microsoft.quantum.techniques.intro
 This section of our documentation details the core concepts used to create quantum programs in Q#, and to interact with those programs from classical .NET applications.
 We assume *some* knowledge of quantum computing concepts like those described in [Quantum computing concepts](xref:microsoft.quantum.concepts.intro), but you needn't be an expert in quantum computing to get a lot from these sections.
 
+Their contents are as follows.
 
+- [Q# program overview](xref:microsoft.quantum.techniques.file-structure) provides an overview of the purpose and functionality of the Q# programming language. 
+	In particular, it clarifies how Q# is *not* a language for merely simulating quantum mechanics---though that functionality is of course provided by our full state simulator. 
+	Rather, Q# was designed with an eye on the future, and its programs describe how a classical control computer *interacts* with qubits. 
 
+- [Operations and functions](xref:microsoft.quantum.techniques.opsandfunctions) details the two callable types of the Q# language: *operations*, which include action on qubits and quantum systems; and *functions*, which strictly work with classical information. 
+	Without both classical and quantum information working in tandem, quantum computing would remain out of reach. 
+	This section describes how to define and use these callables within the control flow of a Q# program.
 
+- [Local variables](xref:microsoft.quantum.techniques.local-variables) describes the role of variables within Q# programs and how to leverage them effectively. 
+	In particular, you will learn the difference between immutable/mutable variables and how to assign/re-assign them.
 
+- [Working with qubits](xref:microsoft.quantum.techniques.qubits) describes the features of Q# that you can use to address individual qubits and systems of qubits. 
+	Specifically, that entails their allocation, or blocking off a certain number of qubits for an operation or program to use; performing operations on them; and ultimately their measurement. 
+	Additionally, you will learn some useful control-flow techniques.
 
+- In [Putting it all together](xref:microsoft.quantum.techniques.puttingittogether), you will leverage the techniques from the sections above to create a program which performs **quantum teleportation**: using two classical bits to "teleport" the full state of one qubit onto another.
 
+- [Going further](xref:microsoft.quantum.techniques.going-further) introduces advanced techniques that can prove helpful as you move toward more complex quantum programming. 
+	In particular, we discuss the use of *generic* operations and functions in Q#, which enable higher-order control flow by remaining agnostic to the specific types of their input/output, as well as *borrowing* qubits. 
+	The latter differs from basic qubit allocation in that a Q# operation may use "dirty" qubits---qubits not necessarily initialized to a known state---to assist computations.
 
-
-
-
-
-
-
-
-
+- [Testing and debugging](xref:microsoft.quantum.techniques.testing-and-debugging) details some techniques for making sure your code is doing what it is supposed to. 
+	Due to the general opacity of quantum information, debugging a quantum program can require specialized techniques. 
+	Fortunately, Q# supports many of the classical debugging techniques programmers are used to, as well as those that are quantum-specific. These include creating/running unit tests in Q#, embedding *assertions* on values and probabilities in your code, and the `Dump` functions which output the state of target machine. 
+	The latter can be used alongside our full state simulator to debug certain parts of computations by skirting some quantum limitations (e.g. the no-cloning theorem).
 
 
 ![Quantum](~/media/mobius_strip_preview.png)

--- a/articles/techniques/index.md
+++ b/articles/techniques/index.md
@@ -12,26 +12,26 @@ uid: microsoft.quantum.techniques.intro
 
 # Quantum Development Techniques
 
+This section of our documentation details the core concepts used to create quantum programs in Q#, and to interact with those programs from classical .NET applications.
+We assume *some* knowledge of quantum computing concepts like those described in [Quantum computing concepts](xref:microsoft.quantum.concepts.intro), but you needn't be an expert in quantum computing to get a lot from these sections.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ![Quantum](~/media/mobius_strip_preview.png)
-
-This section details the core concepts used to create quantum programs in Q#, and to interact with those programs from classical .NET applications.
-This section assumes some knowledge of quantum computing concepts like those described in [Quantum computing concepts](xref:microsoft.quantum.concepts.intro).
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 

--- a/articles/techniques/local-variables.md
+++ b/articles/techniques/local-variables.md
@@ -1,11 +1,12 @@
 ---
 # Mandatory fields. See more on aka.ms/skyeye/meta.
-title: Q# techniques - local variables | Microsoft Docs 
-description: Q# techniques - local variables
+title: Local variables - Q# techniques | Microsoft Docs 
+description: Local variables - Q# techniques 
 author: QuantumWriter
 ms.author: Christopher.Granade@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
+uid: microsoft.quantum.techniques.local-variables
 # Use only one of the following. Use ms.service for services, ms.prod for on-prem. Remove the # before the relevant field.
 # For Quantum products none of these categories have been defined  yet.
 # ms.service: service-name-from-white-list

--- a/articles/techniques/operations-and-functions.md
+++ b/articles/techniques/operations-and-functions.md
@@ -1,6 +1,6 @@
 ---
-title: Q# techniques - operations and functions | Microsoft Docs
-description: Q# techniques - operations and functions
+title: Operations and functions - Q# techniques | Microsoft Docs
+description: Operations and functions - Q# techniques 
 uid: microsoft.quantum.techniques.opsandfunctions
 author: QuantumWriter
 ms.author: Christopher.Granade@microsoft.com

--- a/articles/techniques/putting-it-all-together.md
+++ b/articles/techniques/putting-it-all-together.md
@@ -1,7 +1,7 @@
 ---
 # Mandatory fields. See more on aka.ms/skyeye/meta.
-title: Q# techniques - putting it all together | Microsoft Docs 
-description: Q# techniques - putting it all together
+title: Putting it all together - Q# techniques | Microsoft Docs 
+description: Putting it all together - Q# techniques
 uid: microsoft.quantum.techniques.puttingittogether
 author: QuantumWriter
 ms.author: Christopher.Granade@microsoft.com
@@ -14,7 +14,7 @@ ms.topic: article
 # ms.technology: tech-name-from-white-list
 ---
 
-# Putting it All Together: Teleportation #
+# Putting It All Together: Teleportation #
 Let's return to the example of the teleportation circuit defined in [Quantum Circuits](xref:microsoft.quantum.concepts.circuits). We're going to use this to illustrate the concepts we've learned so far. An explanation of quantum teleportation is provided below for those who are unfamiliar with the theory, followed by a walkthrough of the code implementation in Q#. 
 
 ## Quantum Teleportation: Theory

--- a/articles/techniques/testing-and-debugging.md
+++ b/articles/techniques/testing-and-debugging.md
@@ -1,6 +1,6 @@
 ---
-title: Q# techniques - testing and debugging | Microsoft Docs
-description: Q# techniques - testing and debugging
+title: Testing and debugging - Q# techniques | Microsoft Docs
+description: Testing and debugging - Q# techniques
 author: tcNickolas
 ms.author: mamykhai@microsoft.com
 uid: microsoft.quantum.techniques.testing-and-debugging

--- a/articles/techniques/working-with-qubits.md
+++ b/articles/techniques/working-with-qubits.md
@@ -1,6 +1,6 @@
 ---
-title: Working with Qubits | Microsoft Docs 
-description: Working with Qubits
+title: Working with Qubits - Q# techniques | Microsoft Docs 
+description: Working with Qubits - Q# techniques
 author: QuantumWriter
 ms.author: Christopher.Granade@microsoft.com
 ms.date: 12/11/2017


### PR DESCRIPTION
The [page](https://docs.microsoft.com/en-us/quantum/techniques/?view=qsharp-preview) was practically just a placeholder, so updated it to be more a roadmap of the section's pages (akin to the ["Q# Programming Language" section overview page](https://docs.microsoft.com/en-us/quantum/language/?view=qsharp-preview)). This will be particularly helpful in letting us usefully link to the page from the cards on the main page (PR #625).

Additionally, updated some of the pages' metadata (titles/descriptions) to be more internally consistent/descriptive and allow users to see the actual page title when they have a tab open (currently they just see "Q# techniques ..." and if they have multiple tabs it becomes a frustrating guessing game of clicks)