### PR TITLE
Improve Pauli measurements and working with qubits conceptual articles.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        // Suggest that users have the MS Docs Authoring Pack, which provides
+        // a number of tools for working with DocFX-based documentation repos.
+        "docsmsft.docs-authoring-pack"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "markdownlint.config": {
+        "default": true,
+        // Use #-style section headings without the ending # marks, as that can
+        // cause problems working with the Samples Browser.
+        "MD003": {"style": "atx"},
+        "MD013": false
+    }
+}

--- a/api/docfx.json
+++ b/api/docfx.json
@@ -39,15 +39,7 @@
     "overwrite": [],
     "externalReference": [],
     "globalMetadata": {
-      "latex_macros": {
-        "ket": ["\\left| #1\\right\\rangle", 1],
-        "bra": ["\\left\\langle #1\\right|", 1],
-        "braket": ["\\left\\langle #1 \\right\\rangle", 1],
-        "boldone": "\\mathbf{1}",
-        "expect": "\\mathbb{E}",
-        "variance": "\\operatorname{Var}",
-        "defeq": "\\mathrel{:=}"
-      },
+      "show_latex": true,
       "ms.prod": "quantum",
       "ms.topic": "managed-reference",
       "ms.devlang":"qsharp",
@@ -57,7 +49,21 @@
       "feedback_product_url": "https://github.com/microsoft/quantum/issues",
       "titleSuffix": "Q# reference - Microsoft Quantum"
     },
-    "fileMetadata": {},
+    "fileMetadata": {
+      "latex_macros": {
+        "**/**.yml": {
+          "ket": ["\\left| #1\\right\\rangle", 1],
+          "bra": ["\\left\\langle #1\\right|", 1],
+          "braket": [ "\\left\\langle #1 \\right\\rangle", 1 ],
+          "id": "\\mathbb{1}",
+          "boldone": "\\mathbf{1}",
+          "expect": "\\mathbb{E}",
+          "variance": "\\operatorname{Var}",
+          "defeq": "\\mathrel{:=}",
+          "dd": "\\mathrm{d}"
+        }
+      }
+    },
     "template": [],
     "dest": "quantum-api"
   }

--- a/articles/concepts/pauli-measurements.md
+++ b/articles/concepts/pauli-measurements.md
@@ -11,10 +11,11 @@ ms.topic: article
 # Pauli Measurements
 
 In the previous discussions, we have focused on computational basis measurements.
-In fact there are other common measurements that occur in quantum computing that, from a notational perspective, are convenient to express in terms of computational basis measurements.
-The most common set of these measurements are *Pauli measurements*.
+In fact, there are other common measurements that occur in quantum computing that, from a notational perspective, are convenient to express in terms of computational basis measurements.
+As you work with Q#, the most common kind of measurements that you'll run into will likely be *Pauli measurements*.
 In such cases, it is common to discuss measuring a Pauli operator, in general an operator such as $X,Y,Z$ or $Z\otimes Z, X\otimes X, X\otimes Y$ and so forth.
-Discussing measurement in terms of Pauli operators is especially common in the subfield of quantum error correction. In Q# we follow a similar convention; we now explain this alternative view of measurements.
+Discussing measurement in terms of Pauli operators is especially common in the subfield of quantum error correction.
+In Q# we follow a similar convention; we now explain this alternative view of measurements.
 
 Before delving into the details of how to think of a Pauli measurement, it is useful to think about what measuring a single qubit inside a quantum computer does to the quantum state.
 Imagine that we have an $n$-qubit quantum state; then measuring one qubit immediately rules out half of the $2^n$ possibilities that state could be in.
@@ -45,7 +46,7 @@ These measurements are given below for convenience.
 |-------------------|------------------------|
 | $Z$               | $\boldone$             |
 | $X$               | $H$                    |
-| $Y$               | $HS^{\dagger}          |
+| $Y$               | $HS^{\dagger}$         |
 
 That is, using this language, "measure $Y$" is equivalent to applying $HS^\dagger$ and then measuring in the computational basis, where [`S`](xref:microsoft.quantum.intrinsic.s) is an intrinsic quantum operation sometimes called the "phase gate," and can be simulated by the unitary matrix
 
@@ -111,12 +112,12 @@ We enumerate the transformations in the following table.
 > $$
 > \begin{align}
 >     \operatorname{SWAP} & =
->     \left(
+>     \left(\begin{matrix}
 >         1 & 0 & 0 & 0 \\\\
 >         0 & 0 & 1 & 0 \\\\
 >         0 & 1 & 0 & 0 \\\\
 >         0 & 0 & 0 & 1
->     \right)
+>     \end{matrix}\right)
 > \end{align}
 > $$
 > used to simulate the intrinsic operation [`SWAP`](xref:microsoft.quantum.intrinsic).
@@ -176,7 +177,7 @@ One such limitation is given by the *No-Cloning Theorem*.
 The No-Cloning Theorem is aptly named.
 It disallows cloning of generic quantum states by a quantum computer.
 The proof of the theorem is remarkably straightforward.
-While a full proof of the no-cloning theorem is a little too technical for our discussion here, the proof of the theorem in the case where the quantum computer in question has no additional auxillary qubits is within our scope (auxillary qubits are qubits used for scratch space during a computation and are easily used and managed in Q#, see <xref:microsoft.quantum.techniques.qubits>).
+While a full proof of the no-cloning theorem is a little too technical for our discussion here, the proof of the theorem in the case where the quantum computer in question has no additional auxiliary qubits is within our scope (auxiliary qubits are qubits used for scratch space during a computation and are easily used and managed in Q#, see <xref:microsoft.quantum.techniques.qubits>).
 For such a quantum computer, the cloning operation must be described by a unitary matrix.
 We disallow measurement, since it would corrupt the quantum state we are trying to clone.
 We want the unitary matrix used to simulate our cloning operation to have the property that
@@ -195,7 +196,7 @@ $$
 $$
 
 This provides the fundamental intuition behind the No-Cloning Theorem: any device that copies an unknown quantum state must induce errors on at least some of the states it copies.
-While the key assumption that the cloner acts linearly on the input state can be violated through the addition and measurement of auxillary qubits, such interactions also leak information about the system through the measurement statistics and prevent exact cloning in such cases as well.
+While the key assumption that the cloner acts linearly on the input state can be violated through the addition and measurement of auxiliary qubits, such interactions also leak information about the system through the measurement statistics and prevent exact cloning in such cases as well.
 For a more complete proof of the No-Cloning Theorem see [For more information](xref:microsoft.quantum.more-information).
 
 The No-Cloning Theorem is important for qualitative understanding of quantum computing because if you could clone quantum states inexpensively then you would be granted a near-magical ability to learn from quantum states.

--- a/articles/concepts/pauli-measurements.md
+++ b/articles/concepts/pauli-measurements.md
@@ -12,7 +12,7 @@ ms.topic: article
 
 In the previous discussions, we have focused on computational basis measurements.
 In fact, there are other common measurements that occur in quantum computing that, from a notational perspective, are convenient to express in terms of computational basis measurements.
-As you work with Q#, the most common kind of measurements that you'll run into will likely be *Pauli measurements*.
+As you work with Q#, the most common kind of measurements that you'll run into will likely be *Pauli measurements*, which generalize computational basis measurements to include measurements in other bases, of parity between different qubits, and so forth.
 In such cases, it is common to discuss measuring a Pauli operator, in general an operator such as $X,Y,Z$ or $Z\otimes Z, X\otimes X, X\otimes Y$, and so forth.
 
 > [!TIP]
@@ -38,8 +38,9 @@ $$
 $$
 
 By reading the diagonal elements of the Pauli-$Z$ matrix, we can see that $Z$ has two eigenvectors, $\ket{0}$ and $\ket{1}$, with corresponding eigenvalues $\pm 1$.
-Thus, if we measure the qubit and obtain $\ket{0}$ we are in the $+1$ eigenspace (the set of all vectors that are formed of sums of  eigenvectors with only positive or only negative eigenvalues) of the operator and if we measure $\ket{1}$ we are in the $-1$ eigenspace of $Z$.
-This process is referred to in the language of Pauli measurements as "measuring Pauli $Z$" and is entirely equivalent to performing a computational basis measurement.
+Thus, if we measure the qubit and obtain `Zero` (corresponding to the state $\ket{0}$), we know that the state of our qubit is a $+1$ eigenstate of the $Z$ operator.
+Similarly, if we obtain `One`, we know that the state of our qubit is a $-1$ eigenstate of $Z$.
+This process is referred to in the language of Pauli measurements as "measuring Pauli $Z$," and is entirely equivalent to performing a computational basis measurement.
 
 Any $2\times 2$ matrix that is a unitary transformation of $Z$ also satisfies this criteria.
 That is, we could also use a matrix $A=U^\dagger Z U$, where $U$ is any other unitary matrix, to give a matrix that defines the two outcomes of a measurement in its $\pm 1$ eigenvectors.
@@ -162,6 +163,10 @@ Measuring $X\otimes \id$ lets you look at information that is locally stored in 
 While both types of measurements are equally valuable in quantum computing, the former illuminates the power of quantum computing.
 It reveals that in quantum computing often the information you wish to learn is not stored in any single qubit but rather stored non-locally in all the qubits at once, and only by looking at it through a joint measurement with $Z\otimes Z$ does this information become manifest.
 
+For example, in error correction, we often wish to learn what error occured while learning nothing about the state that we're trying to protect.
+The [bit-flip code sample](https://github.com/microsoft/Quantum/tree/master/samples/error-correction/bit-flip-code) shows an example of how you can do that using measurements like $Z \otimes Z \otimes \id$ and $\id \otimes Z \otimes Z$.
+<!-- TODO: change this to a link to the samples browser as soon as the bit-flip code sample is on-boarded. -->
+
 Arbitrary Pauli operators such as $X\otimes Y \otimes Z \otimes \boldone$ can also be measured.
 All such tensor products of Pauli operators have only two eigenvalues $\pm 1$ and both eigenspaces constitute half-spaces of the entire vector space.
 Thus they coincide with the requirements stated above.
@@ -194,9 +199,19 @@ The linearity property of matrix multiplication then implies that for any second
 
 $$
 \begin{align}
-&U\left[\frac{1}{\sqrt{2}}\left(\ket{\phi}+\ket{\psi} \right)\right]\ket{0}=\frac{1}{\sqrt{2}}U\ket{\phi}\ket{0}+\frac{1}{\sqrt{2}}U\ket{\psi}\ket{0}\\\\
-&\qquad\qquad=\frac{1}{\sqrt{2}}\left(\ket{\phi}\ket{\phi}+\ket{\psi}\ket{\psi}\right)\\\\
-&\qquad\qquad\ne \left(\frac{1}{\sqrt{2}}\left(\ket{\phi}+\ket{\psi} \right)\right)\otimes\left(\frac{1}{\sqrt{2}}\left(\ket{\phi}+\ket{\psi} \right)\right).
+    U \left[
+      \frac{1}{\sqrt{2}}\left(\ket{\phi}+\ket{\psi} \right)
+    \right] \ket{0}
+    & = \frac{1}{\sqrt{2}} U\ket{\phi}\ket{0}
+      + \frac{1}{\sqrt{2}} U\ket{\psi}\ket{0} \\\\
+    & = \frac{1}{\sqrt{2}} \left(
+            \ket{\phi} \ket{\phi} + \ket{\psi} \ket{\psi}
+        \right) \\\\
+    & \ne \left(
+          \frac{1}{\sqrt{2}}\left(\ket{\phi}+\ket{\psi} \right)
+      \right) \otimes \left(
+          \frac{1}{\sqrt{2}}\left(\ket{\phi}+\ket{\psi} \right)
+      \right).
 \end{align}
 $$
 

--- a/articles/concepts/pauli-measurements.md
+++ b/articles/concepts/pauli-measurements.md
@@ -1,48 +1,83 @@
 ---
-title: Pauli Measurements | Microsoft Docs 
+title: Pauli Measurements
 description: Pauli Measurements
 author: QuantumWriter
 uid: microsoft.quantum.concepts.pauli
-ms.author: nawiebe@microsoft.com 
+ms.author: nawiebe@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
 ---
 
 # Pauli Measurements
 
-In the previous discussions, we have focused on computational basis measurements.  In fact there are other common measurements that occur in quantum computing that, from a notational perspective, are convenient to express in terms of computational basis measurements.  The most common set of these measurements are *Pauli measurements*.  In such cases, it is common to discuss measuring a Pauli operator, in general an operator such as $X,Y,Z$ or $Z\otimes Z, X\otimes X, X\otimes Y$ and so forth.  Discussing measurement in terms of Pauli operators is especially common in the subfield of quantum error correction. In Q# we follow a similar convention; we now explain this alternative view of measurements.
+In the previous discussions, we have focused on computational basis measurements.
+In fact there are other common measurements that occur in quantum computing that, from a notational perspective, are convenient to express in terms of computational basis measurements.
+The most common set of these measurements are *Pauli measurements*.
+In such cases, it is common to discuss measuring a Pauli operator, in general an operator such as $X,Y,Z$ or $Z\otimes Z, X\otimes X, X\otimes Y$ and so forth.
+Discussing measurement in terms of Pauli operators is especially common in the subfield of quantum error correction. In Q# we follow a similar convention; we now explain this alternative view of measurements.
 
-Before delving into the details of how to think of a Pauli measurement, it is useful to think about what measuring a single qubit inside a quantum computer does to the quantum state.  Imagine that we have an $n$-qubit quantum state; then measuring one qubit immediately rules out half of the $2^n$ possibilities that state could be in.  In other words, the measurement projects the quantum state onto one of two half-spaces.  We can generalize the way we think about measurement to reflect this.
+Before delving into the details of how to think of a Pauli measurement, it is useful to think about what measuring a single qubit inside a quantum computer does to the quantum state.
+Imagine that we have an $n$-qubit quantum state; then measuring one qubit immediately rules out half of the $2^n$ possibilities that state could be in.
+In other words, the measurement projects the quantum state onto one of two half-spaces.
+We can generalize the way we think about measurement to reflect this.
 
-In order to concisely identify these subspaces, we need a language for describing them.  One way to do this is to describe the two subspaces by specifying them through a matrix that just has two unique eigenvalues, taken by convention to be $\pm 1$.  The simplest example of this is:
-
-$$
-  Z = \begin{bmatrix} 1 & 0 \\\\ 0 & -1 \end{bmatrix}.
-$$
-
-The Pauli-$Z$ matrix clearly has two eigenvectors $\ket{0}$ and $\ket{1}$ with eigenvalues $\pm 1$.  Thus if we measure the qubit and obtain $\ket{0}$ we are in the $+1$ eigenspace (the set of all vectors that are formed of sums of  eigenvectors with only positive or only negative eigenvalues) of the operator and if we measure $\ket{1}$ we are in the $-1$ eigenspace of $Z$.  This process is referred to in the language of Pauli measurements as "measuring Pauli $Z$" and is entirely equivalent to performing a computational basis measurement.
-
-Of course any $2\times 2$ matrix that is a unitary transformation of $Z$ also satisfies this criteria.  This is to say that we could also consider matrix $A=U^\dagger Z U$, for any unitary matrix $U$, to give a matrix that defines the two outcomes of a measurement in its $\pm 1$ eigenvectors.  The notation of Pauli measurements references this by identifying $X,Y,Z$ measurements as equivalent measurements that one could do to gain information from a qubit.  These measurements are given below for convenience.
-
-$$
-\begin{array}{|c|c|}
-\text{Pauli Measurement} & U\\\\ 
-Z & \boldone\\\\ 
-X & H\\\\ 
-Y & HS^\dagger\\\\ 
-\end{array}
-$$
-
-That is, using this language, "measure $Y$" is equivalent to applying $HS^\dagger$ and then measuring in the computational basis, where $S$ is the so-called phase gate given by
+In order to concisely identify these subspaces, we need a language for describing them.
+One way to do this is to describe the two subspaces by specifying them through a matrix that just has two unique eigenvalues, taken by convention to be $\pm 1$.
+The simplest example of this is:
 
 $$
-\begin{bmatrix}1 &0\\\\  0&i\end{bmatrix}.
+\begin{align}
+  Z & = \begin{bmatrix} 1 & 0 \\\\ 0 & -1 \end{bmatrix}.
+\end{align}
 $$
 
-It is also equivalent to applying $HS^\dagger$ to the quantum state vector and then measuring $Z$.  The correct state would then be found by transforming back to the computational basis, which amounts to applying $SH$ to the quantum state vector.
+The Pauli-$Z$ matrix clearly has two eigenvectors $\ket{0}$ and $\ket{1}$ with eigenvalues $\pm 1$.
+Thus if we measure the qubit and obtain $\ket{0}$ we are in the $+1$ eigenspace (the set of all vectors that are formed of sums of  eigenvectors with only positive or only negative eigenvalues) of the operator and if we measure $\ket{1}$ we are in the $-1$ eigenspace of $Z$.
+This process is referred to in the language of Pauli measurements as "measuring Pauli $Z$" and is entirely equivalent to performing a computational basis measurement.
 
-## Q# outcome classical information obtained from quantum state
-In Q# we say the outcome, i.e., the classical information extracted from interacting with the state, is $j$ which is in the set $\{0,1\}$ if the result is in the $(-1)^j$ eigenspace of the Pauli operator measured.
+Of course any $2\times 2$ matrix that is a unitary transformation of $Z$ also satisfies this criteria.
+This is to say that we could also consider matrix $A=U^\dagger Z U$, for any unitary matrix $U$, to give a matrix that defines the two outcomes of a measurement in its $\pm 1$ eigenvectors.
+The notation of Pauli measurements references this by identifying $X,Y,Z$ measurements as equivalent measurements that one could do to gain information from a qubit.
+These measurements are given below for convenience.
+
+
+|Pauli Measurement  |Unitary transformation  |
+|-------------------|------------------------|
+| $Z$               | $\boldone$             |
+| $X$               | $H$                    |
+| $Y$               | $HS^{\dagger}          |
+
+That is, using this language, "measure $Y$" is equivalent to applying $HS^\dagger$ and then measuring in the computational basis, where [`S`](xref:microsoft.quantum.intrinsic.s) is an intrinsic quantum operation sometimes called the "phase gate," and can be simulated by the unitary matrix
+
+$$
+\begin{align}
+    S = \begin{bmatrix}
+        1 & 0 \\\\ 0 & i
+    \end{bmatrix}.
+\end{align}
+$$
+
+It is also equivalent to applying $HS^\dagger$ to the quantum state vector and then measuring $Z$, such that the following operation is equivalent to `Measure([PauliY], [q]])`:
+
+```Q#
+operation MeasureY(q : Qubit) : Result {
+    mutable result = Zero;
+    within {
+        H(q);
+        Adjoint S(q);
+    } apply {
+        set result = M(q);
+    }
+    return result;
+}
+```
+
+The correct state would then be found by transforming back to the computational basis, which amounts to applying $SH$ to the quantum state vector; in the above snippet, this is handled automatically by the use of the `within … apply` block.
+
+In Q# we say the outcome, i.e., the classical information extracted from interacting with the state, is given by a `Result` value $j \in \{\texttt{Zero}, \texttt{One}\}$ indicating if the result is in the $(-1)^j$ eigenspace of the Pauli operator measured.
+
+
+## Multiple-qubit measurements
 
 Measurements of multi-qubit Pauli operators are defined similarly, as seen from:
 
@@ -50,71 +85,125 @@ $$
 Z\otimes Z = \begin{bmatrix}1 &0 &0&0\\\\  0&-1&0&0\\\\ 0&0&-1&0\\\\ 0&0&0&1\end{bmatrix}.
 $$
 
-Thus the tensor products of two Pauli-$Z$ operators forms a matrix composed of two spaces consisting of $+1$ and $-1$ eigenvalues.  As with the single-qubit case, both constitute a half-space meaning that half of the accessible vector space belongs to the $+1$ eigenspace and the remaining half to the $-1$ eigenspace.  In general, it is easy to see from the definition of the tensor product that any tensor product of Pauli-$Z$ operators and the identity also obeys this.  For example,
+Thus the tensor products of two Pauli-$Z$ operators forms a matrix composed of two spaces consisting of $+1$ and $-1$ eigenvalues.
+As with the single-qubit case, both constitute a half-space meaning that half of the accessible vector space belongs to the $+1$ eigenspace and the remaining half to the $-1$ eigenspace.
+In general, it is easy to see from the definition of the tensor product that any tensor product of Pauli-$Z$ operators and the identity also obeys this.
+For example,
 
 $$
-Z\otimes\boldone=\begin{bmatrix} 1&0&0&0\\\\  0&1&0&0\\\\  0&0&-1&0\\\\ 0&0&0&-1\end{bmatrix}.
+\begin{align}
+    Z \otimes \boldone = \begin{bmatrix}
+        1 &  0 &  0 &  0 \\\\
+        0 &  1 &  0 &  0 \\\\
+        0 &  0 & -1 &  0 \\\\
+        0 &  0 &  0 & -1
+    \end{bmatrix}.
+\end{align}
 $$
 
-As before, any unitary transformation of such matrices also describes two half-spaces labeled by $\pm 1$ eigenvalues.  For example, $X\otimes X = H\otimes H(Z\otimes Z)H\otimes H$  from the identity that $Z=HXH$.  Similar to the one-qubit case, all two-qubit Pauli-measurements can be written as $U^\dagger (Z\otimes \id) U$ for $4\times 4$ unitary matrices $U$.  We enumerate the transformations in the following table where we introduce for convenience the swap gate which swaps qubits $0$ and $1$: $\operatorname{SWAP}=\operatorname{CNOT}\_{01}\operatorname{CNOT}\_{10}\operatorname{CNOT}\_{01}$:
+As before, any unitary transformation of such matrices also describes two half-spaces labeled by $\pm 1$ eigenvalues.
+For example, $X\otimes X = H\otimes H(Z\otimes Z)H\otimes H$  from the identity that $Z=HXH$.
+Similar to the one-qubit case, all two-qubit Pauli-measurements can be written as $U^\dagger (Z\otimes \id) U$ for $4\times 4$ unitary matrices $U$. 
+We enumerate the transformations in the following table.
 
-$$
-\begin{array}{|c|c|}
-\text{Pauli Measurement} & U\\\\ 
-\hline
-Z\otimes \boldone & \boldone\otimes \boldone\\\\ 
-X\otimes \boldone & H\otimes \boldone\\\\ 
-Y\otimes \boldone & HS^\dagger\otimes \boldone\\\\ 
-\boldone \otimes Z & \operatorname{SWAP}\\\\ 
-\boldone \otimes X & (H\otimes \boldone)\operatorname{SWAP}\\\\ 
-\boldone \otimes Y & (HS^\dagger\otimes \boldone)\operatorname{SWAP}\\\\ 
-Z\otimes Z & \operatorname{CNOT}\_{10}\\\\ 
-X\otimes Z & \operatorname{CNOT}\_{10}(H\otimes \boldone)\\\\ 
-Y\otimes Z & \operatorname{CNOT}\_{10}(HS^\dagger\otimes \boldone)\\\\ 
-Z\otimes X & \operatorname{CNOT}\_{10}(\boldone\otimes H)\\\\ 
-X\otimes X & \operatorname{CNOT}\_{10}(H\otimes H)\\\\ 
-Y\otimes X & \operatorname{CNOT}\_{10}(HS^\dagger\otimes H)\\\\ 
-Z\otimes Y & \operatorname{CNOT}\_{10}(\boldone \otimes HS^\dagger)\\\\ 
-X\otimes Y & \operatorname{CNOT}\_{10}(H\otimes HS^\dagger)\\\\ 
-Y\otimes Y & \operatorname{CNOT}\_{10}(HS^\dagger\otimes HS^\dagger)\\\\ 
-\end{array}
-$$
+> [!NOTE]
+> In the table below, we use $\operatorname{SWAP}$ to indicate the matrix
+> $$
+> \begin{align}
+>     \operatorname{SWAP} & =
+>     \left(
+>         1 & 0 & 0 & 0 \\\\
+>         0 & 0 & 1 & 0 \\\\
+>         0 & 1 & 0 & 0 \\\\
+>         0 & 0 & 0 & 1
+>     \right)
+> \end{align}
+> $$
+> used to simulate the intrinsic operation [`SWAP`](xref:microsoft.quantum.intrinsic).
 
-Here the gate $\operatorname{CNOT}\_{10}$ appears for the following reason.  Each Pauli measurement that does not include the $\boldone$ matrix is equivalent up to a unitary to $Z\otimes Z$ by the above reasoning.  The eigenvalues of $Z\otimes Z$ only depend on the parity of the qubits that comprise each computational basis vector and the controlled-not operations that appear in this list serve to compute this parity and store it in the first bit.  Then once the first bit is measured, we can recover the identity of the resultant half-space which is equivalent to measuring the Pauli operator.
+|Pauli Measurement     |Unitary transformation  |
+|----------------------|------------------------|
+| $Z \otimes \boldone$ | $\boldone \otimes \boldone$ |
+| $Z\otimes \boldone$ | $\boldone\otimes \boldone$ |
+| $X\otimes \boldone$ | $H\otimes \boldone$ |
+| $Y\otimes \boldone$ | $HS^\dagger\otimes \boldone$ |
+| $\boldone \otimes Z$ | $\operatorname{SWAP}$ |
+| $\boldone \otimes X$ | $(H\otimes \boldone)\operatorname{SWAP}$ |
+| $\boldone \otimes Y$ | $(HS^\dagger\otimes \boldone)\operatorname{SWAP}$ |
+| $Z\otimes Z$ | $\operatorname{CNOT}\_{10}$ |
+| $X\otimes Z$ | $\operatorname{CNOT}\_{10}(H\otimes \boldone)$ |
+| $Y\otimes Z$ | $\operatorname{CNOT}\_{10}(HS^\dagger\otimes \boldone)$ |
+| $Z\otimes X$ | $\operatorname{CNOT}\_{10}(\boldone\otimes H)$ |
+| $X\otimes X$ | $\operatorname{CNOT}\_{10}(H\otimes H)$ |
+| $Y\otimes X$ | $\operatorname{CNOT}\_{10}(HS^\dagger\otimes H)$ |
+| $Z\otimes Y$ | $\operatorname{CNOT}\_{10}(\boldone \otimes HS^\dagger)$ |
+| $X\otimes Y$ | $\operatorname{CNOT}\_{10}(H\otimes HS^\dagger)$ |
+| $Y\otimes Y$ | $\operatorname{CNOT}\_{10}(HS^\dagger\otimes HS^\dagger)$ |
 
-One additional note, while it may be tempting to assume that measuring $Z\otimes Z$ is the same as measuring $Z\otimes \id$ and then $\id \otimes Z$, this assumption would be false.  The reason is that measuring $Z\otimes Z$ projects the quantum state into either the $+1$ or $-1$ eigenstate of these operators.  Measuring $Z\otimes \id$ and then $\id \otimes Z$ projects the quantum state vector first onto a half space of $Z\otimes \id$ and then onto a half space of $\id \otimes Z$.  As there are four computational basis vectors, performing both measurements reduces the state to a quarter-space and hence reduces it to a single computational basis vector.
+Here, the [`CNOT`](xref:microsoft.quantum.intrinsic.cnot) operation appears for the following reason.
+Each Pauli measurement that does not include the $\boldone$ matrix is equivalent up to a unitary to $Z\otimes Z$ by the above reasoning.
+The eigenvalues of $Z\otimes Z$ only depend on the parity of the qubits that comprise each computational basis vector and the controlled-not operations that appear in this list serve to compute this parity and store it in the first bit.
+Then once the first bit is measured, we can recover the identity of the resultant half-space which is equivalent to measuring the Pauli operator.
 
+One additional note, while it may be tempting to assume that measuring $Z\otimes Z$ is the same as measuring $Z\otimes \mathbb{1}$ and then $\mathbb{1} \otimes Z$, this assumption would be false.
+The reason is that measuring $Z\otimes Z$ projects the quantum state into either the $+1$ or $-1$ eigenstate of these operators.
+Measuring $Z\otimes \mathbb{1}$ and then $\mathbb{1} \otimes Z$ projects the quantum state vector first onto a half space of $Z\otimes \mathbb{1}$ and then onto a half space of $\mathbb{1} \otimes Z$.
+As there are four computational basis vectors, performing both measurements reduces the state to a quarter-space and hence reduces it to a single computational basis vector.
 
 ## Correlations between qubits
-Another way of looking at measuring tensor products of Paulis such as $X\otimes X$ or $Z\otimes Z$ is that these measurements let you look at information stored in the correlations between the two qubits.  Measuring $X\otimes \id$ lets you look at information that is locally stored in the first qubit.  While both types of measurements are equally valuable in quantum computing, the former illuminates the power of quantum computing. It reveals that in quantum computing often the information you wish to learn is not stored in any single qubit but rather stored non-locally in all the qubits at once, and only by looking at it through a joint measurement with $Z\otimes Z$ does this information become manifest.
+Another way of looking at measuring tensor products of Paulis such as $X\otimes X$ or $Z\otimes Z$ is that these measurements let you look at information stored in the correlations between the two qubits.
+Measuring $X\otimes \id$ lets you look at information that is locally stored in the first qubit.
+While both types of measurements are equally valuable in quantum computing, the former illuminates the power of quantum computing.
+It reveals that in quantum computing often the information you wish to learn is not stored in any single qubit but rather stored non-locally in all the qubits at once, and only by looking at it through a joint measurement with $Z\otimes Z$ does this information become manifest.
 
-Arbitrary Pauli operators such as $X\otimes Y \otimes Z \otimes \boldone$ can also be measured.  All such tensor products of Pauli operators have only two eigenvalues $\pm 1$ and both eigenspaces constitute half-spaces of the entire vector space.  Thus they coincide with the requirements stated above.
+Arbitrary Pauli operators such as $X\otimes Y \otimes Z \otimes \boldone$ can also be measured.
+All such tensor products of Pauli operators have only two eigenvalues $\pm 1$ and both eigenspaces constitute half-spaces of the entire vector space.
+Thus they coincide with the requirements stated above.
 
-In Q#, such measurements return $j$ if the measurement yields a result in the eigenspace of sign $(-1)^j$.  Having this as a built-in feature in Q# is helpful because measuring such operators requires long chains of controlled-NOT gates and basis transformations to describe the diagonalizing $U$ gate needed to express the operation as a tensor product of $Z$ and $\id$.  By simply being able to specify that you wish to do one of these pre-defined measurements, you don't need to worry about how to transform your basis such that a computational basis measurement provides the necessary information.  Q# handles all the necessary basis transformations for you automatically. See [Q# library reference for Pauli measurements](/qsharp/api/canon/microsoft.quantum.canon.measurepaulis)
+In Q#, such measurements return $j$ if the measurement yields a result in the eigenspace of sign $(-1)^j$.
+Having this as a built-in feature in Q# is helpful because measuring such operators requires long chains of controlled-NOT gates and basis transformations to describe the diagonalizing $U$ gate needed to express the operation as a tensor product of $Z$ and $\id$.
+By simply being able to specify that you wish to do one of these pre-defined measurements, you don't need to worry about how to transform your basis such that a computational basis measurement provides the necessary information.
+Q# handles all the necessary basis transformations for you automatically.
+See the [`Measure`](xref:microsoft.quantum.intrinsic.measure) and [`MeasurePaulis`](xref:microsoft.quantum.measurement.measurepaulis) operations for more details.
 
 ## The No-Cloning Theorem
-Quantum information is powerful.  It enables us to do amazing things such as factor numbers exponentially faster than the best known classical algorithms, or efficiently simulate correlated electron systems that classically require exponential cost to simulate accurately.  However, there are limitations to the power of quantum computing.  One such limitation is given by the *No-Cloning Theorem*.
+
+Quantum information is powerful.
+It enables us to do amazing things such as factor numbers exponentially faster than the best known classical algorithms, or efficiently simulate correlated electron systems that classically require exponential cost to simulate accurately.
+However, there are limitations to the power of quantum computing.
+One such limitation is given by the *No-Cloning Theorem*.
 
 The No-Cloning Theorem is aptly named.
 It disallows cloning of generic quantum states by a quantum computer.
 The proof of the theorem is remarkably straightforward.
-While a full proof of the no-cloning theorem is a little too technical for our discussion here, the proof of the theorem in the case where the quantum computer in question has no additional ancilla qubits is within our scope (ancilla qubits are qubits used for scratch space during a computation and are easily used and managed in Q#, see <xref:microsoft.quantum.techniques.qubits>).
-For such a quantum computer, the cloning operation must be a unitary matrix. We disallow measurement, since it would corrupt the quantum state we are trying to clone. The unitary matrix we want must have the property that
+While a full proof of the no-cloning theorem is a little too technical for our discussion here, the proof of the theorem in the case where the quantum computer in question has no additional auxillary qubits is within our scope (auxillary qubits are qubits used for scratch space during a computation and are easily used and managed in Q#, see <xref:microsoft.quantum.techniques.qubits>).
+For such a quantum computer, the cloning operation must be described by a unitary matrix.
+We disallow measurement, since it would corrupt the quantum state we are trying to clone.
+We want the unitary matrix used to simulate our cloning operation to have the property that
 $$
-  U \ket{\psi} \ket{0} = \ket{\psi} \ket{\psi},
+  U \ket{\psi} \ket{0} = \ket{\psi} \ket{\psi}
 $$
 for any state $\ket{\psi}$.
 The linearity property of matrix multiplication then implies that for any second quantum state $\ket{\phi}$,
 
+$$
 \begin{align}
 &U\left[\frac{1}{\sqrt{2}}\left(\ket{\phi}+\ket{\psi} \right)\right]\ket{0}=\frac{1}{\sqrt{2}}U\ket{\phi}\ket{0}+\frac{1}{\sqrt{2}}U\ket{\psi}\ket{0}\\\\
 &\qquad\qquad=\frac{1}{\sqrt{2}}\left(\ket{\phi}\ket{\phi}+\ket{\psi}\ket{\psi}\right)\\\\
 &\qquad\qquad\ne \left(\frac{1}{\sqrt{2}}\left(\ket{\phi}+\ket{\psi} \right)\right)\otimes\left(\frac{1}{\sqrt{2}}\left(\ket{\phi}+\ket{\psi} \right)\right).
 \end{align}
+$$
 
-This provides the fundamental intuition behind the No-Cloning Theorem: any device that copies an unknown quantum state must induce errors on at least some of the states it copies.  While the key assumption that the cloner acts linearly on the input state can be violated through the addition of ancilla and measurement of the ancilla qubits, such interactions also leak information about the system through the measurement statistics and prevent exact cloning in such cases as well.  For a more complete proof of the No-Cloning Theorem see [For more information](xref:microsoft.quantum.more-information).
+This provides the fundamental intuition behind the No-Cloning Theorem: any device that copies an unknown quantum state must induce errors on at least some of the states it copies.
+While the key assumption that the cloner acts linearly on the input state can be violated through the addition and measurement of auxillary qubits, such interactions also leak information about the system through the measurement statistics and prevent exact cloning in such cases as well.
+For a more complete proof of the No-Cloning Theorem see [For more information](xref:microsoft.quantum.more-information).
 
-The No-Cloning Theorem is important for qualitative understanding of quantum computing because if you could clone quantum states inexpensively then you would be granted a near-magical ability to learn from quantum states.  Indeed, you could violate Heisenberg's vaunted uncertainty principle.  Alternatively, you could use an optimal cloner to take a single sample from a complex quantum distribution and learn everything you could possibly learn about that distribution from just one sample.  This would be like you flipping a coin and observing heads and then upon telling a friend about the result having them respond "Ah the distribution of that coin must be Bernoulli with $p=0.512643\ldots$!"  Such a statement would be non-sensical because one bit of information (the heads outcome) simply cannot provide the many bits of information needed to encode the distribution without substantial prior information.  Similarly, without prior information we cannot perfectly clone a quantum state just as we cannot prepare an ensemble of such coins without knowing $p$.
+The No-Cloning Theorem is important for qualitative understanding of quantum computing because if you could clone quantum states inexpensively then you would be granted a near-magical ability to learn from quantum states.
+Indeed, you could violate Heisenberg's vaunted uncertainty principle.
+Alternatively, you could use an optimal cloner to take a single sample from a complex quantum distribution and learn everything you could possibly learn about that distribution from just one sample.
+This would be like you flipping a coin and observing heads and then upon telling a friend about the result having them respond "Ah the distribution of that coin must be Bernoulli with $p=0.512643\ldots$!"  Such a statement would be non-sensical because one bit of information (the heads outcome) simply cannot provide the many bits of information needed to encode the distribution without substantial prior information.
+Similarly, without prior information we cannot perfectly clone a quantum state just as we cannot prepare an ensemble of such coins without knowing $p$.
 
-Information is not free in quantum computing.  Each qubit measured gives a single bit of information, and the No-Cloning Theorem shows that there is no backdoor that can be exploited to get around the fundamental tradeoff between information gained about the system and the disturbance invoked upon it.
+Information is not free in quantum computing.
+Each qubit measured gives a single bit of information, and the No-Cloning Theorem shows that there is no backdoor that can be exploited to get around the fundamental tradeoff between information gained about the system and the disturbance invoked upon it.
 

--- a/articles/concepts/pauli-measurements.md
+++ b/articles/concepts/pauli-measurements.md
@@ -20,16 +20,16 @@ In such cases, it is common to discuss measuring a Pauli operator, in general an
 > For example, to represent $X \otimes Z \otimes Y$, you can use the array `[PauliX, PauliZ, PauliY]`.
 
 Discussing measurement in terms of Pauli operators is especially common in the subfield of quantum error correction.
-In Q# we follow a similar convention; we now explain this alternative view of measurements.
+In Q#, we follow a similar convention; we now explain this alternative view of measurements.
 
 Before delving into the details of how to think of a Pauli measurement, it is useful to think about what measuring a single qubit inside a quantum computer does to the quantum state.
 Imagine that we have an $n$-qubit quantum state; then measuring one qubit immediately rules out half of the $2^n$ possibilities that state could be in.
 In other words, the measurement projects the quantum state onto one of two half-spaces.
-We can generalize the way we think about measurement to reflect this.
+We can generalize the way we think about measurement to reflect this intuition.
 
 In order to concisely identify these subspaces, we need a language for describing them.
-One way to do this is to describe the two subspaces by specifying them through a matrix that just has two unique eigenvalues, taken by convention to be $\pm 1$.
-The simplest example of this is:
+One way to describe the two subspaces is by specifying them through a matrix that just has two unique eigenvalues, taken by convention to be $\pm 1$.
+For a simple example of describing subspaces in this way, consider $Z$:
 
 $$
 \begin{align}
@@ -37,13 +37,13 @@ $$
 \end{align}
 $$
 
-The Pauli-$Z$ matrix clearly has two eigenvectors $\ket{0}$ and $\ket{1}$ with eigenvalues $\pm 1$.
-Thus if we measure the qubit and obtain $\ket{0}$ we are in the $+1$ eigenspace (the set of all vectors that are formed of sums of  eigenvectors with only positive or only negative eigenvalues) of the operator and if we measure $\ket{1}$ we are in the $-1$ eigenspace of $Z$.
+By reading the diagonal elements of the Pauli-$Z$ matrix, we can see that $Z$ has two eigenvectors, $\ket{0}$ and $\ket{1}$, with corresponding eigenvalues $\pm 1$.
+Thus, if we measure the qubit and obtain $\ket{0}$ we are in the $+1$ eigenspace (the set of all vectors that are formed of sums of  eigenvectors with only positive or only negative eigenvalues) of the operator and if we measure $\ket{1}$ we are in the $-1$ eigenspace of $Z$.
 This process is referred to in the language of Pauli measurements as "measuring Pauli $Z$" and is entirely equivalent to performing a computational basis measurement.
 
-Of course any $2\times 2$ matrix that is a unitary transformation of $Z$ also satisfies this criteria.
-This is to say that we could also consider matrix $A=U^\dagger Z U$, for any unitary matrix $U$, to give a matrix that defines the two outcomes of a measurement in its $\pm 1$ eigenvectors.
-The notation of Pauli measurements references this by identifying $X,Y,Z$ measurements as equivalent measurements that one could do to gain information from a qubit.
+Any $2\times 2$ matrix that is a unitary transformation of $Z$ also satisfies this criteria.
+That is, we could also use a matrix $A=U^\dagger Z U$, where $U$ is any other unitary matrix, to give a matrix that defines the two outcomes of a measurement in its $\pm 1$ eigenvectors.
+The notation of Pauli measurements references this unitary equivalence by identifying $X,Y,Z$ measurements as equivalent measurements that one could do to gain information from a qubit.
 These measurements are given below for convenience.
 
 
@@ -78,9 +78,9 @@ operation MeasureY(q : Qubit) : Result {
 }
 ```
 
-The correct state would then be found by transforming back to the computational basis, which amounts to applying $SH$ to the quantum state vector; in the above snippet, this is handled automatically by the use of the `within … apply` block.
+The correct state would then be found by transforming back to the computational basis, which amounts to applying $SH$ to the quantum state vector; in the above snippet, the transformation back to the computational basis is handled automatically by the use of the `within … apply` block.
 
-In Q# we say the outcome, i.e., the classical information extracted from interacting with the state, is given by a `Result` value $j \in \{\texttt{Zero}, \texttt{One}\}$ indicating if the result is in the $(-1)^j$ eigenspace of the Pauli operator measured.
+In Q#, we say the outcome, that is, the classical information extracted from interacting with the state, is given by a `Result` value $j \in \{\texttt{Zero}, \texttt{One}\}$ indicating if the result is in the $(-1)^j$ eigenspace of the Pauli operator measured.
 
 
 ## Multiple-qubit measurements
@@ -149,7 +149,7 @@ We enumerate the transformations in the following table.
 Here, the [`CNOT`](xref:microsoft.quantum.intrinsic.cnot) operation appears for the following reason.
 Each Pauli measurement that does not include the $\boldone$ matrix is equivalent up to a unitary to $Z\otimes Z$ by the above reasoning.
 The eigenvalues of $Z\otimes Z$ only depend on the parity of the qubits that comprise each computational basis vector and the controlled-not operations that appear in this list serve to compute this parity and store it in the first bit.
-Then once the first bit is measured, we can recover the identity of the resultant half-space which is equivalent to measuring the Pauli operator.
+Then once the first bit is measured, we can recover the identity of the resultant half-space, which is equivalent to measuring the Pauli operator.
 
 One additional note, while it may be tempting to assume that measuring $Z\otimes Z$ is the same as measuring $Z\otimes \mathbb{1}$ and then $\mathbb{1} \otimes Z$, this assumption would be false.
 The reason is that measuring $Z\otimes Z$ projects the quantum state into either the $+1$ or $-1$ eigenstate of these operators.
@@ -157,7 +157,7 @@ Measuring $Z\otimes \mathbb{1}$ and then $\mathbb{1} \otimes Z$ projects the qua
 As there are four computational basis vectors, performing both measurements reduces the state to a quarter-space and hence reduces it to a single computational basis vector.
 
 ## Correlations between qubits
-Another way of looking at measuring tensor products of Paulis such as $X\otimes X$ or $Z\otimes Z$ is that these measurements let you look at information stored in the correlations between the two qubits.
+Another way of looking at measuring tensor products of Pauli matrices such as $X\otimes X$ or $Z\otimes Z$ is that these measurements let you look at information stored in the correlations between the two qubits.
 Measuring $X\otimes \id$ lets you look at information that is locally stored in the first qubit.
 While both types of measurements are equally valuable in quantum computing, the former illuminates the power of quantum computing.
 It reveals that in quantum computing often the information you wish to learn is not stored in any single qubit but rather stored non-locally in all the qubits at once, and only by looking at it through a joint measurement with $Z\otimes Z$ does this information become manifest.
@@ -167,10 +167,10 @@ All such tensor products of Pauli operators have only two eigenvalues $\pm 1$ an
 Thus they coincide with the requirements stated above.
 
 In Q#, such measurements return $j$ if the measurement yields a result in the eigenspace of sign $(-1)^j$.
-Having this as a built-in feature in Q# is helpful because measuring such operators requires long chains of controlled-NOT gates and basis transformations to describe the diagonalizing $U$ gate needed to express the operation as a tensor product of $Z$ and $\id$.
-By simply being able to specify that you wish to do one of these pre-defined measurements, you don't need to worry about how to transform your basis such that a computational basis measurement provides the necessary information.
+Having Pauli measurements as a built-in feature in Q# is helpful because measuring such operators requires long chains of controlled-NOT gates and basis transformations to describe the diagonalizing $U$ gate needed to express the operation as a tensor product of $Z$ and $\id$.
+By being able to specify that you wish to do one of these pre-defined measurements, you don't need to worry about how to transform your basis such that a computational basis measurement provides the necessary information.
 Q# handles all the necessary basis transformations for you automatically.
-See the [`Measure`](xref:microsoft.quantum.intrinsic.measure) and [`MeasurePaulis`](xref:microsoft.quantum.measurement.measurepaulis) operations for more details.
+For more information, see the [`Measure`](xref:microsoft.quantum.intrinsic.measure) and [`MeasurePaulis`](xref:microsoft.quantum.measurement.measurepaulis) operations.
 
 ## The No-Cloning Theorem
 

--- a/articles/concepts/pauli-measurements.md
+++ b/articles/concepts/pauli-measurements.md
@@ -13,7 +13,12 @@ ms.topic: article
 In the previous discussions, we have focused on computational basis measurements.
 In fact, there are other common measurements that occur in quantum computing that, from a notational perspective, are convenient to express in terms of computational basis measurements.
 As you work with Q#, the most common kind of measurements that you'll run into will likely be *Pauli measurements*.
-In such cases, it is common to discuss measuring a Pauli operator, in general an operator such as $X,Y,Z$ or $Z\otimes Z, X\otimes X, X\otimes Y$ and so forth.
+In such cases, it is common to discuss measuring a Pauli operator, in general an operator such as $X,Y,Z$ or $Z\otimes Z, X\otimes X, X\otimes Y$, and so forth.
+
+> [!TIP]
+> In Q#, multi-qubit Pauli operators are generally represented by arrays of type `Pauli[]`.
+> For example, to represent $X \otimes Z \otimes Y$, you can use the array `[PauliX, PauliZ, PauliY]`.
+
 Discussing measurement in terms of Pauli operators is especially common in the subfield of quantum error correction.
 In Q# we follow a similar convention; we now explain this alternative view of measurements.
 

--- a/articles/concepts/pauli-measurements.md
+++ b/articles/concepts/pauli-measurements.md
@@ -12,7 +12,7 @@ ms.topic: article
 
 In the previous discussions, we have focused on computational basis measurements.
 In fact, there are other common measurements that occur in quantum computing that, from a notational perspective, are convenient to express in terms of computational basis measurements.
-As you work with Q#, the most common kind of measurements that you'll run into will likely be *Pauli measurements*, which generalize computational basis measurements to include measurements in other bases, of parity between different qubits, and so forth.
+As you work with Q#, the most common kind of measurements that you'll run into will likely be *Pauli measurements*, which generalize computational basis measurements to include measurements in other bases, and of parity between different qubits.
 In such cases, it is common to discuss measuring a Pauli operator, in general an operator such as $X,Y,Z$ or $Z\otimes Z, X\otimes X, X\otimes Y$, and so forth.
 
 > [!TIP]

--- a/articles/contributing/index.md
+++ b/articles/contributing/index.md
@@ -57,7 +57,7 @@ Each of these different pieces finds its home on a different repository, so the 
 > [!NOTE]
 > We unfortunately cannot accept code and documentation contributions on the [**microsoft/Quantum-NC**](https://github.com/microsoft/Quantum-NC) repository at this time, but we still very much appreciate bug reports.
 
-There are also a few other, more specialized repositories focusing on different events, or on auxillary functionality related to the Quantum Development Kit.
+There are also a few other, more specialized repositories focusing on different events, or on auxiliary functionality related to the Quantum Development Kit.
 
 - [**msr-quarc/qsharp.sty**](https://github.com/msr-quarc/qsharp.sty): LaTeX formatting support for Q# syntax.
 - [**msr-quarc/intern-workshop-2019**](https://github.com/msr-quarc/intern-workshop-2019): IQ# Notebook for Deutsch–Jozsa tutorial given at the 2019 intern workshop.

--- a/articles/libraries/standard/characterization.md
+++ b/articles/libraries/standard/characterization.md
@@ -35,11 +35,11 @@ In discussing iterative phase estimation, we will consider a unitary $U$ given a
 As described in the section on oracles in [data structures](xref:microsoft.quantum.libraries.data-structures), the Q# canon models such operations by the <xref:microsoft.quantum.oracles.discreteoracle> user-defined type, defined by the tuple type `((Int, Qubit[]) => Unit : Adjoint, Controlled)`.
 Concretely, if `U : DiscreteOracle`, then `U(m)` implements $U^m$ for `m : Int`.
 
-With this definition in place, each step of iterative phase estimation proceeds by preparing an auxillary qubit in the $\ket{+}$ state along with the initial state $\ket{\phi}$ that we assume is an [eigenvector](xref:microsoft.quantum.concepts.matrix-advanced) of $U(m)$, i.e. $U(m)\ket{\phi}= e^{im\phi}\ket{\phi}$.  
+With this definition in place, each step of iterative phase estimation proceeds by preparing an auxiliary qubit in the $\ket{+}$ state along with the initial state $\ket{\phi}$ that we assume is an [eigenvector](xref:microsoft.quantum.concepts.matrix-advanced) of $U(m)$, i.e. $U(m)\ket{\phi}= e^{im\phi}\ket{\phi}$.  
 A controlled application of `U(m)` is then used which prepares the state $\left(R\_1(m \phi) \ket{+}\right)\ket{\phi}$.
 As in the quantum case, the effect of a controlled application of the oracle `U(m)` is precisely the same as the effect of applying $R_1$ for the unknown phase on $\ket{+}$, such that we can describe the effects of $U$ in this simpler fashion.
 Optionally, the algorithm then rotates the control qubit by applying $R_1(-m\theta)$ to obtain a state $\ket{\psi}=\left(R\_1(m [\phi-\theta]) \ket{+}\right)\ket{\phi}$$.
-The auxillary qubit used as a control for `U(m)` is then measured in the $X$ basis to obtain a single classical `Result`.
+The auxiliary qubit used as a control for `U(m)` is then measured in the $X$ basis to obtain a single classical `Result`.
 
 At this point, reconstructing the phase from the `Result` values obtained through iterative phase estimation is a classical statistical inference problem.
 Finding the value of $m$ that maximizes the information gained, given a fixed inference method, is simply a problem in statistics.
@@ -198,7 +198,7 @@ operation H2EstimateEnergy(
 : Double
 ```
 
-These myriad phase estimation algorithms are optimized for different properties and input parameters, which must be understood to make the best choice for the target application. For instance, some phase estimation algorithms are adaptive, meaning that future steps are classically controlled by the measurement results of previous steps. Some require the ability to exponentiate its black-box unitary oracle by arbitrary real powers, and others only require integer powers but are only able to resolve a phase estimate modulo $2\pi$. Some require many auxillary qubits, and other require only one.
+These myriad phase estimation algorithms are optimized for different properties and input parameters, which must be understood to make the best choice for the target application. For instance, some phase estimation algorithms are adaptive, meaning that future steps are classically controlled by the measurement results of previous steps. Some require the ability to exponentiate its black-box unitary oracle by arbitrary real powers, and others only require integer powers but are only able to resolve a phase estimate modulo $2\pi$. Some require many auxiliary qubits, and other require only one.
 
 Similarly, using random walk phase estimation proceeds in much the same way as for other algorithms provided with the canon:
 

--- a/articles/techniques/working-with-qubits.md
+++ b/articles/techniques/working-with-qubits.md
@@ -43,7 +43,6 @@ The `X` operation lets us prepare states of the form $\ket{s_0 s_1 \dots s_n}$ f
 ```qsharp
 operation PrepareBitString(bitstring : Bool[], register : Qubit[]) : Unit
 is Adj + Ctl {
-
     let nQubits = Length(register);
     for (idxQubit in 0..nQubits - 1) {
         if (bitstring[idxQubit]) {
@@ -52,14 +51,15 @@ is Adj + Ctl {
     }
 }
 
-operation Example() : Unit {
-
+operation RunExample() : Unit {
     using (register = Qubit[8]) {
         PrepareBitString(
             [true, true, false, false, true, false, false, true],
             register
         );
         // At this point, register now has the state |11001001〉.
+        // Resetting the qubits will allow us to deallocate them properly.
+        ResetAll(register);
     }
 }
 ```
@@ -71,7 +71,6 @@ We can also prepare states such as $\ket{+} = \left(\ket{0} + \ket{1}\right) / \
 
 ```qsharp
 operation PreparePlusMinusState(bitstring : Bool[], register : Qubit[]) : Unit {
-
     // First, get a computational basis state of the form
     // |s_0 s_1 ... s_n〉 by using PrepareBitString, above.
     PrepareBitString(bitstring, register);

--- a/articles/techniques/working-with-qubits.md
+++ b/articles/techniques/working-with-qubits.md
@@ -38,7 +38,7 @@ We will see these operations in more detail in [Intrinsic Operations and Functio
 
 First, the single-qubit Pauli operators $X$, $Y$, and $Z$ are represented in Q# by the intrinsic operations `X`, `Y`, and `Z`, each of which has type `(Qubit => Unit is Adj + Ctl)`.
 As described in [Intrinsic Operations and Functions](xref:microsoft.quantum.libraries.standard.prelude), we can think of $X$ and hence of `X` as a bit-flip operation or NOT gate.
-This lets us prepare states of the form $\ket{s_0 s_1 \dots s_n}$ for some classical bit string $s$:
+The `X` operation lets us prepare states of the form $\ket{s_0 s_1 \dots s_n}$ for some classical bit string $s$:
 
 ```qsharp
 operation PrepareBitString(bitstring : Bool[], register : Qubit[]) : Unit
@@ -85,18 +85,18 @@ operation PreparePlusMinusState(bitstring : Bool[], register : Qubit[]) : Unit {
 
 ## Measurements
 
-Using the `Measure` operation, which is a built in intrinsic non-unitary operation, we can extract classical information from an object of type `Qubit` and assign a classical value as a result, which has a reserved type `Result`, indicating that the result is no longer a quantum state.
-The input to `Measure` is a Pauli axis on the Bloch sphere, represented by an object of type `Pauli` (i.e., for instance `PauliX`) and an object of type `Qubit`.
+Using the `Measure` operation, which is a built-in intrinsic non-unitary operation, we can extract classical information from an object of type `Qubit` and assign a classical value as a result, which has a reserved type `Result`, indicating that the result is no longer a quantum state.
+The input to `Measure` is a Pauli axis on the Bloch sphere, represented by an value of type `Pauli` (for instance `PauliX`) and an value of type `Qubit`.
 
-A simple example is the following operation which creates one qubit in the $\ket{0}$ state, then applies a Hadamard gate ``H`` to it and then measures the result in the `PauliZ` basis.
+A simple example is the following operation, which allocates one qubit in the $\ket{0}$ state, then applies a Hadamard operation `H` to it and then measures the result in the `PauliZ` basis.
 
 ```qsharp
 operation MeasureOneQubit() : Result {
     // The following using block creates a fresh qubit and initializes it
     // in the |0〉 state.
     using (qubit = Qubit()) {
-        // We apply a Hadamard operation H to the state, thereby creating the
-        // state 1/sqrt(2)(|0〉+|1〉).
+        // We apply a Hadamard operation H to the state, thereby preparing the
+        // state 1 / sqrt(2) (|0〉 + |1〉).
         H(qubit);
         // Now we measure the qubit in Z-basis.
         let result = M(qubit);
@@ -109,7 +109,7 @@ operation MeasureOneQubit() : Result {
 }
 ```
 
-A slightly more complicated example is given by the following operation which returns the Boolean value `true` if all qubits in a register of type `Qubit[]` are in the state zero, when measured in a specified Pauli basis and `false` otherwise.
+A slightly more complicated example is given by the following operation, which returns the Boolean value `true` if all qubits in a register of type `Qubit[]` are in the state zero when measured in a specified Pauli basis, and which returns `false` otherwise.
 
 ```qsharp
 operation MeasureIfAllQubitsAreZero(qs : Qubit[], pauli : Pauli) : Bool {
@@ -123,8 +123,10 @@ operation MeasureIfAllQubitsAreZero(qs : Qubit[], pauli : Pauli) : Bool {
 }
 ```
 
-The Q# language allows dependencies of classical control flow on measurement results of qubits. This in turn enables to implement powerful probabilistic gadgets that can reduce the computational cost for implementing unitaries.
-As an example, it is easy to implement so-called *Repeat-Until-Success* in Q# which are probabilistic programs that have an *expected* low cost in terms of elementary gates, but for which the true cost depends on an actual run and an actual interleaving of various possible branchings.
+The Q# language allows classical control flow to depend on the results of measuring qubits.
+This capability in turn enables implementing powerful probabilistic gadgets that can reduce the computational cost for implementing unitaries.
+As an example, it is easy to implement so-called *Repeat-Until-Success* (RUS) patterns in Q#.
+These RUS patterns are probabilistic programs that have an *expected* low cost in terms of elementary gates, but for which the true cost depends on an actual run and an actual interleaving of various possible branchings.
 
 To facilitate Repeat-Until-Success (RUS) patterns, Q# supports the construct
 
@@ -212,5 +214,5 @@ operation PrepareStateUsingRUS(target : Qubit) : Unit {
 }
 ```
 
-Notable programmatic features shown in this operation are a more complex `fixup` part of the loop which involves quantum operations, and the use of `AssertProb` statements to ascertain the probability of measuring the quantum state at certain specified points in the program.
+Notable programmatic features shown in this operation are a more complex `fixup` part of the loop, which involves quantum operations, and the use of `AssertProb` statements to ascertain the probability of measuring the quantum state at certain specified points in the program.
 See also [Testing and debugging](xref:microsoft.quantum.techniques.testing-and-debugging) for more information about the [`Assert`](xref:microsoft.quantum.intrinsic.assert) and [`AssertProb`](xref:microsoft.quantum.intrinsic.assertprob) operations.

--- a/articles/techniques/working-with-qubits.md
+++ b/articles/techniques/working-with-qubits.md
@@ -1,5 +1,5 @@
 ---
-title: Working with Qubits | Microsoft Docs 
+title: Working with Qubits
 description: Working with Qubits
 author: QuantumWriter
 ms.author: Christopher.Granade@microsoft.com
@@ -8,11 +8,11 @@ ms.topic: article
 uid: microsoft.quantum.techniques.qubits
 ---
 
-# Working with Qubits #
+# Working with Qubits
 
 Having now seen a variety of different parts of the Q# language, let us get into the thick of it and see how to use qubits themselves.
 
-## Allocating Qubits ##
+## Allocating Qubits
 
 First, to obtain a qubit that we can use in Q#, we *allocate* qubits within a `using` block:
 
@@ -28,9 +28,9 @@ At the end of the `using` block, any qubits allocated by that block are immediat
 > [!WARNING]
 > Target machines expect that qubits are in the $\ket{0}$ state immediately before deallocation, so that they can be reused and offered to other `using` blocks for allocation.
 > Whenever possible, use unitary operations to return any allocated qubits to $\ket{0}$.
-> If need be, the @"microsoft.quantum.intrinsic.reset" operation can be used to measure a qubit instead, and to use that measurement result to ensure that the measured qubit is returned to $\ket{0}$. Such a measurement will destroy any entanglement with the remaining qubits and can thus impact the computation. 
+> If need be, the @"microsoft.quantum.intrinsic.reset" operation can be used to measure a qubit instead, and to use that measurement result to ensure that the measured qubit is returned to $\ket{0}$. Such a measurement will destroy any entanglement with the remaining qubits and can thus impact the computation.
 
-## Intrinsic Operations ##
+## Intrinsic Operations
 
 Once allocated, a qubit can then be passed to functions and operations.
 In some sense, this is all that a Q# program can do with a qubit, as the actions that can be taken are all defined as operations.
@@ -41,7 +41,7 @@ As described in [Intrinsic Operations and Functions](xref:microsoft.quantum.libr
 This lets us prepare states of the form $\ket{s_0 s_1 \dots s_n}$ for some classical bit string $s$:
 
 ```qsharp
-operation PrepareBitString(bitstring : Bool[], register : Qubit[]) : Unit 
+operation PrepareBitString(bitstring : Bool[], register : Qubit[]) : Unit
 is Adj + Ctl {
 
     let nQubits = Length(register);
@@ -83,41 +83,39 @@ operation PreparePlusMinusState(bitstring : Bool[], register : Qubit[]) : Unit {
 }
 ```
 
-## Measurements ##
+## Measurements
 
-Using the `Measure` operation, which is a built in intrinsic non-unitary operation, we can extract classical information from an object of type `Qubit` and assign a classical value as a result, which has a reserved type `Result`, indicating that the result is no longer a quantum state. 
-The input to `Measure` is a Pauli axis on the Bloch sphere, represented by an object of type `Pauli` (i.e., for instance `PauliX`) and an object of type `Qubit`. 
+Using the `Measure` operation, which is a built in intrinsic non-unitary operation, we can extract classical information from an object of type `Qubit` and assign a classical value as a result, which has a reserved type `Result`, indicating that the result is no longer a quantum state.
+The input to `Measure` is a Pauli axis on the Bloch sphere, represented by an object of type `Pauli` (i.e., for instance `PauliX`) and an object of type `Qubit`.
 
-A simple example is the following operation which creates one qubit in the $\ket{0}$ state, then applies a Hadamard gate ``H`` to it and then measures the result in the `PauliZ` basis. 
+A simple example is the following operation which creates one qubit in the $\ket{0}$ state, then applies a Hadamard gate ``H`` to it and then measures the result in the `PauliZ` basis.
 
 ```qsharp
-operation MeasurementOneQubit () : Result {
-
-    // The following using block creates a fresh qubit and initializes it 
+operation MeasureOneQubit() : Result {
+    // The following using block creates a fresh qubit and initializes it
     // in the |0〉 state.
     using (qubit = Qubit()) {
-        // We apply a Hadamard operation H to the state, thereby creating the 
-        // state 1/sqrt(2)(|0〉+|1〉). 
-        H(qubit); 
+        // We apply a Hadamard operation H to the state, thereby creating the
+        // state 1/sqrt(2)(|0〉+|1〉).
+        H(qubit);
         // Now we measure the qubit in Z-basis.
         let result = M(qubit);
-        // As the qubit is now in an eigenstate of the measurement operator, 
-        // we reset the qubit before releasing it. 
-        if (result == One) { X(qubit); }   
-        // Finally, we return the result of the measurement. 
+        // As the qubit is now in an eigenstate of the measurement operator,
+        // we reset the qubit before releasing it.
+        if (result == One) { X(qubit); }
+        // Finally, we return the result of the measurement.
         return result;
     }
 }
 ```
 
-A slightly more complicated example is given by the following operation which returns the Boolean value `true` if all qubits in a register of type `Qubit[]` are in the state zero, when measured in a specified Pauli basis and `false` otherwise. 
+A slightly more complicated example is given by the following operation which returns the Boolean value `true` if all qubits in a register of type `Qubit[]` are in the state zero, when measured in a specified Pauli basis and `false` otherwise.
 
 ```qsharp
-operation AllMeasurementsZero (qs : Qubit[], pauli : Pauli) : Bool {
-
+operation MeasureIfAllQubitsAreZero(qs : Qubit[], pauli : Pauli) : Bool {
     mutable value = true;
     for (q in qs) {
-        if ( Measure([pauli], [q]) == One ) {
+        if (Measure([pauli], [q]) == One) {
             set value = false;
         }
     }
@@ -125,36 +123,38 @@ operation AllMeasurementsZero (qs : Qubit[], pauli : Pauli) : Bool {
 }
 ```
 
-The Q# language allows dependencies of classical control flow on measurement results of qubits. This in turn enables to implement powerful probabilistic gadgets that can reduce the computational cost for implementing unitaries. As an example, it is easy to implement so-called *Repeat-Until-Success* in Q# which are probabilistic circuits that have an *expected* low cost in terms of elementary gates, but for which the true cost depends on an actual run and an actual interleaving of various possible branchings. 
+The Q# language allows dependencies of classical control flow on measurement results of qubits. This in turn enables to implement powerful probabilistic gadgets that can reduce the computational cost for implementing unitaries.
+As an example, it is easy to implement so-called *Repeat-Until-Success* in Q# which are probabilistic programs that have an *expected* low cost in terms of elementary gates, but for which the true cost depends on an actual run and an actual interleaving of various possible branchings.
 
 To facilitate Repeat-Until-Success (RUS) patterns, Q# supports the construct
+
 ```qsharp
 repeat {
-    statementBlock1 
+    statementBlock1
 }
 until (expression)
 fixup {
     statementBlock2
 }
 ```
-where `statementBlock1` and `statementBlock2` are zero or more Q# statements, and `expression` any valid expression that evaluates to a value of type `Bool`. 
-In a typical use case, the following circuit implements a rotation around an irrational axis of $(I + 2i Z)/\sqrt{5}$ on the Bloch sphere. This is accomplished by using a known RUS pattern: 
+
+where `statementBlock1` and `statementBlock2` are zero or more Q# statements, and `expression` any valid expression that evaluates to a value of type `Bool`.
+In a typical use case, the following Q# operation implements a rotation around an irrational axis of $(I + 2i Z)/\sqrt{5}$ on the Bloch sphere. This is accomplished by using a known RUS pattern:
 
 ```qsharp
-operation RUScircuit (qubit : Qubit) : Unit {
-
-    using(ancillas = Qubit[2]) {
-        ApplyToEachA(H, ancillas);
+operation ApplyVRotationUsingRUS(qubit : Qubit) : Unit {
+    using (controls = Qubit[2]) {
+        ApplyToEachA(H, controls);
         mutable finished = false;
         repeat {
-            Controlled X(ancillas, qubit);
+            Controlled X(controls, qubit);
             S(qubit);
-            Controlled X(ancillas, qubit);
+            Controlled X(controls, qubit);
             Z(qubit);
         }
-        until(finished)
+        until (finished)
         fixup {
-            if AllMeasurementsZero(ancillas, Xpauli) {
+            if (MeasureIfAllQubitsAreZero(controls, PauliX)) {
                 set finished = true;
             }
         }
@@ -164,49 +164,53 @@ operation RUScircuit (qubit : Qubit) : Unit {
 
 This example shows the use of a mutable variable `finished` which is in scope of the entire repeat-until-fixup loop and which gets initialized before the loop and updated in the fixup step.
 
-Finally, we show an example of a RUS pattern to prepare a quantum state $\frac{1}{\sqrt{3}}\left(\sqrt{2}\ket{0}+\ket{1}\right)$, starting from the $\ket{+}$ state. See also the [unit testing sample provided with the standard library](https://github.com/microsoft/Quantum/blob/master/samples/diagnostics/unit-testing/RepeatUntilSuccessCircuits.qs): 
+Finally, we show an example of a RUS pattern to prepare a quantum state $\frac{1}{\sqrt{3}}\left(\sqrt{2}\ket{0}+\ket{1}\right)$, starting from the $\ket{+}$ state.
+See also the [unit testing sample provided with the standard library](https://github.com/microsoft/Quantum/blob/master/samples/diagnostics/unit-testing/RepeatUntilSuccessCircuits.qs):
 
 ```qsharp
-operation RepeatUntilSuccessStatePreparation( target : Qubit ) : Unit {
-
-    using( ancilla = Qubit() ) {
-        H(ancilla);
+operation PrepareStateUsingRUS(target : Qubit) : Unit {
+    using (auxiliary = Qubit()) {
+        H(auxiliary);
         repeat {
-            // We expect target and ancilla qubit to be in |+⟩ state.
-            AssertProb( 
-                [PauliX], [target], Zero, 1.0, 
+            // We expect the target and auxiliary qubits to each be in
+            // the |+⟩ state.
+            AssertProb(
+                [PauliX], [target], Zero, 1.0,
                 "target qubit should be in the |+⟩ state", 1e-10 );
-            AssertProb( 
-                [PauliX], [ancilla], Zero, 1.0,
-                "ancilla qubit should be in the |+⟩ state", 1e-10 );
-                
-            Adjoint T(ancilla);
-            CNOT(target, ancilla);
-            T(ancilla);
+            AssertProb(
+                [PauliX], [auxiliary], Zero, 1.0,
+                "auxiliary qubit should be in the |+⟩ state", 1e-10 );
 
-            // The probability of measuring |+⟩ state on ancilla is 3/4.
-            AssertProb( 
-                [PauliX], [ancilla], Zero, 3. / 4., 
-                "Error: the probability to measure |+⟩ in the first 
-                ancilla must be 3/4",
+            Adjoint T(auxiliary);
+            CNOT(target, auxiliary);
+            T(auxiliary);
+
+            // The probability of measuring |+⟩ state on the auxiliary qubit
+            // is 3/4.
+            AssertProb(
+                [PauliX], [auxiliary], Zero, 3. / 4.,
+                "Error: the probability to measure |+⟩ in the first
+                auxiliary must be 3/4",
                 1e-10);
 
-            // If we get measurement outcome Zero, we prepare the required state 
-            let outcome = Measure([PauliX], [ancilla]);
+            // If we get the measurement outcome Zero, we prepare the
+            // required state.
+            let outcome = Measure([PauliX], [auxiliary]);
         }
-        until( outcome == Zero )
+        until (outcome == Zero)
         fixup {
-            // Bring ancilla and target back to |+⟩ state
-            if( outcome == One ) {
-                Z(ancilla);
+            // Bring the auxiliary and target qubits back to |+⟩ state.
+            if (outcome == One) {
+                Z(auxiliary);
                 X(target);
                 H(target);
             }
         }
-        // Return ancilla back to Zero state
-        H(ancilla);
+        // Return the auxiliary qubit back to the Zero state.
+        H(auxiliary);
     }
 }
 ```
- 
-Notable programmatic features shown in this operation are a more complex `fixup` part of the loop which involves quantum operations, and the use of `AssertProb` statements to ascertain the probability of measuring the quantum state at certain specified points in the program. See also [Testing and debugging](xref:microsoft.quantum.techniques.testing-and-debugging) for more information about `Assert` and `AssertProb` statements. 
+
+Notable programmatic features shown in this operation are a more complex `fixup` part of the loop which involves quantum operations, and the use of `AssertProb` statements to ascertain the probability of measuring the quantum state at certain specified points in the program.
+See also [Testing and debugging](xref:microsoft.quantum.techniques.testing-and-debugging) for more information about the [`Assert`](xref:microsoft.quantum.intrinsic.assert) and [`AssertProb`](xref:microsoft.quantum.intrinsic.assertprob) operations.


### PR DESCRIPTION
This PR:
- Fixes #651.
- Applies various DocFX-Flavored Markdown (DFM) and LaTeX fixes to two conceptual articles.
- Adds new Q# snippets.
- Improves style guide usage on existing snippets.
- Clarifies the distinction between intrinsic operations and the unitary matrices used to simulate them.
- Adds new links to intrinsic operations as appropriate.