### PR TITLE
Primitive to Intrinsic

### DIFF
--- a/articles/concepts/circuits.md
+++ b/articles/concepts/circuits.md
@@ -34,7 +34,7 @@ For example, the symbol
 <!-- Can't find a way to easily center this... probably an extension needed:  -->
 ![](~/media/concepts_2.png)
 
-is the [Hadamard](xref:microsoft.quantum.primitive.h) gate acting on a single-qubit register.
+is the [Hadamard](xref:microsoft.quantum.intrinsic.h) gate acting on a single-qubit register.
 
 Quantum gates are ordered in chronological order with the left-most gate as the gate first applied to the qubits.
 In other words, if you picture the wires as holding the quantum state, the wires bring the quantum state through each of the gates in the diagram from left to right.
@@ -77,7 +77,7 @@ In general, we describe such controlled operations in circuit diagrams as
 ![](~/media/concepts_5.png)
 
 Here the black circle denotes the quantum bit on which the gate is controlled and a vertical wire denotes the unitary that is applied when the control qubit takes the value $1$.
-For the special cases where $G=X$ and $G=Z$ we introduce the following notation to describe the controlled version of the gates (note that the controlled-X gate is the [$CNOT$ gate](xref:microsoft.quantum.primitive.cnot)):
+For the special cases where $G=X$ and $G=Z$ we introduce the following notation to describe the controlled version of the gates (note that the controlled-X gate is the [$CNOT$ gate](xref:microsoft.quantum.intrinsic.cnot)):
 
 <!--- ![](.\media\6.svg) --->
 <!-- Can't find a way to easily center this... probably an extension needed:  -->
@@ -102,7 +102,7 @@ Specifically, such a subcircuit looks like:
 <!-- Can't find a way to easily center this... probably an extension needed:  -->
 ![Measurement circuit](~/media/concepts_7.png)
 
-Q# implements a [Measure operator](xref:microsoft.quantum.primitive.measure) for this purpose.
+Q# implements a [Measure operator](xref:microsoft.quantum.intrinsic.measure) for this purpose.
 See the [section on measurements](xref:microsoft.quantum.libraries.standard.prelude#measurements) for more information.
 
 Similarly, the subcircuit

--- a/articles/libraries/chemistry/concepts/algorithms.md
+++ b/articles/libraries/chemistry/concepts/algorithms.md
@@ -71,7 +71,7 @@ $$
 $$
 Here, $e^{-iHt} \ket{00} = e^{it} \ket{00}$ and $e^{-iHt} \ket{01} = e^{-it} \ket{01}$, which can be seen directly as a consequence of the fact that the parity of $00$ is $0$ while the parity of the bit string $01$ is $1$.
 
-Exponentials of Pauli operators can be implemented directly in Q# using the <xref:microsoft.quantum.primitive.exp> operation:
+Exponentials of Pauli operators can be implemented directly in Q# using the <xref:microsoft.quantum.intrinsic.exp> operation:
 ```qsharp
     using(qubits = Qubit[2]){
         let pauliString = [PauliX, PauliX];

--- a/articles/libraries/standard/algorithms.md
+++ b/articles/libraries/standard/algorithms.md
@@ -45,7 +45,7 @@ The Fourier transform is a fundamental tool of classical analysis and is just as
 In addition, the efficiency of the *quantum Fourier transform* (QFT) far surpasses what is possible on a classical machine making it one of the first tools of choice when designing a quantum algorithm.
 
 As an approximate generalization of the QFT, we provide the <xref:microsoft.quantum.canon.approximateqft> operation that allows for further optimizations by pruning rotations that aren't strictly necessary for the desired algorithmic accuracy.
-The approximate QFT requires the dyadic $Z$-rotation operation <xref:microsoft.quantum.primitive.rfrac> as well as the <xref:microsoft.quantum.intrinsic.h> operation.
+The approximate QFT requires the dyadic $Z$-rotation operation <xref:microsoft.quantum.intrinsic.rfrac> as well as the <xref:microsoft.quantum.intrinsic.h> operation.
 The input and output are assumed to be encoded in big endian encoding (lowest bit/qubit is on the left, same as [ket notation](xref:microsoft.quantum.concepts.dirac)).
 The approximation parameter $a$ determines the pruning level of the $Z$-rotations, i.e., $a \in [0..n]$.
 In this case all $Z$-rotations $2\pi/2^k$ where $k > a$ are removed from the QFT circuit.

--- a/articles/machines/qc-trace-simulator/depth-counter.md
+++ b/articles/machines/qc-trace-simulator/depth-counter.md
@@ -48,7 +48,7 @@ config.useDepthCounter = true;
 var sim = new QCTraceSimulator(config);
 var res = ApplySampleWithCCNOT.Run(sim).Result;
 
-double tDepth = sim.GetMetric<Primitive.CCNOT, ApplySampleWithCCNOT>(DepthCounter.Metrics.Depth);
+double tDepth = sim.GetMetric<Intrinsic.CCNOT, ApplySampleWithCCNOT>(DepthCounter.Metrics.Depth);
 double tDepthAll = sim.GetMetric<ApplySampleWithCCNOT>(DepthCounter.Metrics.Depth);
 ```
 
@@ -56,7 +56,7 @@ The first part of the program executes `ApplySampleWithCCNOT`. In the second par
 `QCTraceSimulator.GetMetric` to get the `T` depth of `CCNOT` and `ApplySampleWithCCNOT`: 
 
 ```csharp
-double tDepth = sim.GetMetric<Primitive.CCNOT, ApplySampleWithCCNOT>(DepthCounter.Metrics.Depth);
+double tDepth = sim.GetMetric<Intrinsic.CCNOT, ApplySampleWithCCNOT>(DepthCounter.Metrics.Depth);
 double tDepthAll = sim.GetMetric<ApplySampleWithCCNOT>(DepthCounter.Metrics.Depth);
 ```
 

--- a/articles/machines/resources-estimator.md
+++ b/articles/machines/resources-estimator.md
@@ -112,7 +112,7 @@ The following is the list of metrics estimated by the `ResourcesEstimator`:
 
 ## Providing the Probability of Measurement Outcomes
 
-<xref:microsoft.quantum.primitive.assertprob> from the <xref:microsoft.quantum.intrinsic> namespace can 
+<xref:microsoft.quantum.intrinsic.assertprob> from the <xref:microsoft.quantum.intrinsic> namespace can 
 be used to provide information about the expected probability of a measurement to help drive the execution 
 of the Q# program. The following example illustrates this:
 

--- a/articles/techniques/putting-it-all-together.md
+++ b/articles/techniques/putting-it-all-together.md
@@ -146,7 +146,7 @@ We also need to allocate a qubit `here` which we achieve with a `using` block:
 ```
 
 ### Step 1: Create an entangled state
-We can then create the entangled pair between `here` and `there` by using the @"microsoft.quantum.primitive.h" and @"microsoft.quantum.primitive.cnot" operations:
+We can then create the entangled pair between `here` and `there` by using the @"microsoft.quantum.intrinsic.h" and @"microsoft.quantum.intrinsic.cnot" operations:
 
 ```qsharp
         H(here);
@@ -162,7 +162,7 @@ We then use the next $\operatorname{CNOT}$ and $H$ gates to move our message qub
 ```
 
 ### Step 3 & 4: Measuring and interpreting the result
-Finally, we use @"microsoft.quantum.primitive.m" to perform the measurements and perform the necessary gate operations to get the desired state, as denoted by `if` statements:
+Finally, we use @"microsoft.quantum.intrinsic.m" to perform the measurements and perform the necessary gate operations to get the desired state, as denoted by `if` statements:
 
 ```qsharp
         // Measure out the entanglement


### PR DESCRIPTION
Fixes issue #543. Updates links/references to the deprecated Microsoft.Quantum.Primitive to Microsoft.Quantum.Intrinsic.