### PR TITLE
Fix issue #384

### DIFF
--- a/articles/language/type-model.md
+++ b/articles/language/type-model.md
@@ -140,7 +140,7 @@ We refer to this property as _singleton tuple equivalence_.
 
 A Q# file may define a new named type containing a single value of any legal type.
 For any tuple type `T`, we can declare a new user-defined type that is a subtype of `T` with the `newtype` statement.
-In the @"microsoft.quantum.canon" namespace, for instance, complex numbers are defined as a user-defined type:
+In the @"microsoft.quantum.math" namespace, for instance, complex numbers are defined as a user-defined type:
 
 ```qsharp
 newtype Complex = (Double, Double);

--- a/articles/libraries/standard/applications.md
+++ b/articles/libraries/standard/applications.md
@@ -212,7 +212,7 @@ The circuits to achieve such modular arithmetic have been described in the [quan
 
 While the circuit above corresponds to [Quantum Phase Estimation](xref:microsoft.quantum.characterization.quantumphaseestimation) and explicitly enables order finding, we can reduce the number of qubits required. We can either follow Beauregard's method for order finding as described 
 [on Page 8 of arXiv:quant-ph/0205095v3](https://arxiv.org/pdf/quant-ph/0205095v3.pdf#page=8), or 
-use one of the phase estimation routines available in Microsoft.Quantum.Canon. For example, 
+use one of the phase estimation routines available in Microsoft.Quantum.Characterization. For example, 
 [Robust Phase Estimation](xref:microsoft.quantum.characterization.robustphaseestimation) also uses one extra qubit.
  
 ### Factoring ###

--- a/articles/libraries/standard/characterization.md
+++ b/articles/libraries/standard/characterization.md
@@ -136,7 +136,7 @@ $$
 $$
 where the lower bound is reached in the limit of asymptotically large $Q$, and the upper bound is guaranteed even for small sample sizes.  Note that $n$ selected by the `bitsPrecision` input, which implicitly defines $Q$.
 
-Other relevant details include, say, the small space overhead of just $1$ ancilla qubit, or that the procedure is non-adaptive, meaning the required sequence of quantum experiments is independent of the intermediate measurement outcomes. In this and forthcoming examples where the choice of phase estimation algorithm is important, one should one should refer to the documentation such as @"microsoft.quantum.canon.robustphaseestimation" and the referenced publications therein for more information and for their the implementation.
+Other relevant details include, say, the small space overhead of just $1$ ancilla qubit, or that the procedure is non-adaptive, meaning the required sequence of quantum experiments is independent of the intermediate measurement outcomes. In this and forthcoming examples where the choice of phase estimation algorithm is important, one should one should refer to the documentation such as @"microsoft.quantum.characterization.robustphaseestimation" and the referenced publications therein for more information and for their the implementation.
 
 > [!TIP]
 > There are many samples where robust phase estimation is used. For phase estimation in extracting the ground state energy of various physical system, 


### PR DESCRIPTION
A few old Microsoft.Quantum.Canon references where the operations have since changed namespaces