### PR TITLE
fixed 404 link errors and minor edits

### DIFF
--- a/articles/libraries/chemistry/samples/end-to-end.md
+++ b/articles/libraries/chemistry/samples/end-to-end.md
@@ -9,7 +9,7 @@ uid: microsoft.quantum.chemistry.examples.endtoend
 
 # End-to-end with NWChem #
 
-In this page, we will walk through an example of getting gate counts for quantum chemistry simulation, starting from an [NWChem](http://www.nwchem-sw.org/index.php/Main_Page) input deck.
+In this article, you will walk through an example of getting gate counts for quantum chemistry simulation, starting from an [NWChem](http://www.nwchem-sw.org/index.php/Main_Page) input deck.
 Before proceeding with this example, make sure that you've installed Docker, following the [installation and validation guide](xref:microsoft.quantum.chemistry.concepts.installation).
 
 For more information:
@@ -27,7 +27,7 @@ For more information:
 If you haven't already done so, clone the [Microsoft/Quantum repository](https://github.com/Microsoft/Quantum), which contains samples and utilities for working with the Quantum Development Kit:
 
 ```powershell
-git clone https://github.com/Microsoft/Quantum
+git clone https://github.com/Microsoft/Quantum 
 ```
 
 Once you've cloned `Microsoft/Quantum`, perform `cd` into the `utilities/` folder and import the PowerShell module for working with Docker and NWChem:
@@ -57,7 +57,7 @@ Get-Command -Module InvokeNWChem
 ```
 
 Next, we'll import the `Get-GateCount` command provided with the **GetGateCount** sample.
-For full details, see the [instructions provided with the sample](https://github.com/Microsoft/Quantum/tree/master/Chemistry/GetGateCount).
+For full details, see the [instructions provided with the sample](https://github.com/Microsoft/Quantum/tree/master/samples/chemistry/GetGateCount).
 Next, run the following, substituting `<runtime>` with either `win10-x64`, `osx-x64`, or `linux-x64`, depending on your operating system:
 
 ```powershell
@@ -107,7 +107,7 @@ set tce:qelb  9
 
 ## Producing and Consuming Broombridge Output from NWChem ##
 
-We now have everything we need to produce and consume Broombridge documents.
+You now have everything you need to produce and consume Broombridge documents.
 To run NWChem and produce a Broombridge document for the `h4_sto6g_0.000.nw` input deck, run `Convert-NWChemToBroombridge`:
 
 > [!NOTE]
@@ -118,7 +118,7 @@ To run NWChem and produce a Broombridge document for the `h4_sto6g_0.000.nw` inp
 Convert-NWChemToBroombridge h4_sto6g_0.000.nw 
 ```
 
-This will produce a Broombridge document called `h4_sto6g_0.000.yaml` that we can use with `Get-GateCount`:
+This will produce a Broombridge document called `h4_sto6g_0.000.yaml` that you can use with `Get-GateCount`:
 
 ```powershell
 Get-GateCount -Format YAML h4_sto6g_0.000.yaml
@@ -159,7 +159,7 @@ There are many things to go do from here:
 - Try out different predefined input decks, e.g., by varying the parameter `alpha` in `h4_sto6g_alpha.nw`, 
 - Try modifying the decks by editing the NWChem decks directly, e.g., exploring `STO-nG` models for various choices of n, 
 - Try other predefined NWChem input decks that are available at `nwchem/qa/chem_library_tests`,
-- Try out a suite of predefined Broombridge YAML benchmarks that were generated from NWChem and are available as part of the [Microsoft/Quantum repository](https://github.com/Microsoft/Quantum/tree/master/Chemistry/IntegralData/YAML). These benchmarks include: 
+- Try out a suite of predefined Broombridge YAML benchmarks that were generated from NWChem and are available as part of the [Microsoft/Quantum repository](https://github.com/Microsoft/Quantum/tree/master/samples/chemistry/IntegralData/YAML). These benchmarks include: 
     - small molecules such as molecular hydrogen (H2), Beryllium (Be), Lithium hydride (LiH),
     - larger molecules such as ozone (O3), beta-carotene, cytosine, and many more. 
 - Try out the graphical front-end [EMSL Arrows](https://arrows.emsl.pnnl.gov/api/qsharp_chem) that features an interface to the Microsoft Quantum Development Kit. 

--- a/articles/libraries/chemistry/samples/end-to-end.md
+++ b/articles/libraries/chemistry/samples/end-to-end.md
@@ -27,7 +27,7 @@ For more information:
 If you haven't already done so, clone the [Microsoft/Quantum repository](https://github.com/Microsoft/Quantum), which contains samples and utilities for working with the Quantum Development Kit:
 
 ```powershell
-git clone https://github.com/Microsoft/Quantum 
+git clone https://github.com/Microsoft/Quantum
 ```
 
 Once you've cloned `Microsoft/Quantum`, perform `cd` into the `utilities/` folder and import the PowerShell module for working with Docker and NWChem:

--- a/articles/libraries/chemistry/schema/broombridge.md
+++ b/articles/libraries/chemistry/schema/broombridge.md
@@ -1,5 +1,5 @@
 ---
-title: Broombridge - Quantum Chemistry Schema
+title: Broombridge Quantum Chemistry Schema
 description: Overview of the Broombridge quantum chemistry schema, used to model real-world chemistry problems with the Microsoft Quantum Development Kit. 
 author: martinro
 ms.author: martinro@microsoft.com
@@ -19,7 +19,7 @@ Being YAML-based, Broombridge is a structured, human-readable and human-editable
 - Ground and excited states can be presented using creation sequences.
 - Upper and lower bounds of energy levels can be specified.
 
-Data can be generated from NWChem using various methods. such as using a full installation of NWChem to run chemistry decks (for example the ones provided [here](https://github.com/nwchemgit/nwchem/tree/master/QA/chem_library_tests) that output Broombridge as part of the run), or a docker image of NWChem which can also be used to generate Broombridge from chemistry decks. To get started with computational chemistry quickly without having to install any chemistry software, you can use the visual interface to NWChem provided by [EMSL Arrows](https://arrows.emsl.pnnl.gov/api/qsharp_chem).
+Data can be generated from NWChem using various methods, such as using a full installation of NWChem to run chemistry decks (for example the ones provided in the [NWChem library](https://github.com/nwchemgit/nwchem/tree/master/QA/chem_library_tests) that output Broombridge as part of the run), or a docker image of NWChem which can also be used to generate Broombridge from chemistry decks. To get started with computational chemistry quickly without having to install any chemistry software, you can use the visual interface to NWChem provided by [EMSL Arrows](https://arrows.emsl.pnnl.gov/api/qsharp_chem).
 
 At a high level, the interplay between NWChem and the Microsoft Quantum Development Kit can be visualized as follows:
 ![Chemistry stack](~/media/broombridge.png)

--- a/articles/libraries/chemistry/schema/broombridge.md
+++ b/articles/libraries/chemistry/schema/broombridge.md
@@ -10,19 +10,19 @@ uid: microsoft.quantum.libraries.chemistry.schema.broombridge
 
 # Broombridge Quantum Chemistry Schema # 
 
-Powerful computational chemistry software such as [NWChem](http://www.nwchem-sw.org/) allows to model a wide range of real-world chemistry problems. In order to access NWChem molecular models with the Microsoft Quantum Chemistry library, we use a [YAML](https://en.wikipedia.org/wiki/YAML)-based schema which we call **Broombridge**. The name was chosen in reference to a [landmark](https://en.wikipedia.org/wiki/Broom_Bridge) which in some circles is celebrated as a birthplace of Hamiltonians. 
+Powerful computational chemistry software such as [NWChem](http://www.nwchem-sw.org/) allows you to model a wide range of real-world chemistry problems. In order to access NWChem molecular models with the Microsoft Quantum Chemistry library, you use a [YAML](https://en.wikipedia.org/wiki/YAML)-based schema named **Broombridge**. The name was chosen in reference to a [landmark](https://en.wikipedia.org/wiki/Broom_Bridge) which in some circles is celebrated as a birthplace of Hamiltonians. 
 
-[NWChem](https://github.com/nwchemgit/nwchem) is an Open Source project licensed under the permissive Educational Community License (ECL) 2.0 license. Broombridge is an Open Source schema that is specified [here](xref:microsoft.quantum.libraries.chemistry.schema.broombridge) and that comes with a [definition](https://raw.githubusercontent.com/Microsoft/Quantum/master/Chemistry/Schema/broombridge-0.1.schema.json) following [RFC 2119](https://tools.ietf.org/html/rfc2119) and [validator script](https://raw.githubusercontent.com/Microsoft/Quantum/master/Chemistry/Schema/validator.py) licensed under the MIT license. 
+[NWChem](https://github.com/nwchemgit/nwchem) is an Open Source project licensed under the permissive Educational Community License (ECL) 2.0 license. The [Broombridge Quantum Chemistry Schema](https://docs.microsoft.com/quantum/libraries/chemistry/schema/spec_v_0_2)) is an Open Source schema that includes a [definition](https://raw.githubusercontent.com/Microsoft/Quantum/master/Chemistry/Schema/broombridge-0.1.schema.json) following [RFC 2119](https://tools.ietf.org/html/rfc2119) and a [validator script](https://raw.githubusercontent.com/Microsoft/Quantum/master/Chemistry/Schema/validator.py) licensed under the MIT license. 
 
-Being YAML-based, Broombridge is a structured, human-readable and human-editable way of representing electronic structure problems. In particular, the following data can be represented: 
-- Fermionic Hamiltonians can be represented using one- and two-electron integrals. 
+Being YAML-based, Broombridge is a structured, human-readable and human-editable way of representing electronic structure problems. In particular, the following data can be represented:
+- Fermionic Hamiltonians can be represented using one- and two-electron integrals.
 - Ground and excited states can be presented using creation sequences.
 - Upper and lower bounds of energy levels can be specified.
 
-The data format can be generated from NWChem with effortless ease: a variety of methods is available that range from a full installation of NWChem to run chemistry decks such as the ones provided [here](https://github.com/nwchemgit/nwchem/tree/master/QA/chem_library_tests) and output Broombridge as part of the run, over a docker image of NWchem which can also be used to generate Broombridge from chemistry decks. Finally, a visual method to get started with computational chemistry quickly without having to install any chemistry software is provided by the [EMSL Arrows](https://arrows.emsl.pnnl.gov/api/qsharp_chem) interface to NWChem. 
+Data can be generated from NWChem using various methods. such as using a full installation of NWChem to run chemistry decks (for example the ones provided [here](https://github.com/nwchemgit/nwchem/tree/master/QA/chem_library_tests) that output Broombridge as part of the run), or a docker image of NWChem which can also be used to generate Broombridge from chemistry decks. To get started with computational chemistry quickly without having to install any chemistry software, you can use the visual interface to NWChem provided by [EMSL Arrows](https://arrows.emsl.pnnl.gov/api/qsharp_chem).
 
-At a high level, the interplay between NWChem and the Microsoft Quantum Development Kit can be visualized as follows: 
+At a high level, the interplay between NWChem and the Microsoft Quantum Development Kit can be visualized as follows:
 ![Chemistry stack](~/media/broombridge.png)
-The blue shaded box represents the Broombridge schema, the various grey shaded boxes represent other internal data representations that were chosen to represent and process quantum algorithms for computational chemistry based on real-world chemistry problems. 
+The blue shaded box represents the Broombridge schema, the various grey shaded boxes represent other internal data representations that were chosen to represent and process quantum algorithms for computational chemistry based on real-world chemistry problems.
 
-Multiple chemical representations defined using the Broombridge schema are provided [here](https://github.com/microsoft/Quantum/tree/master/Chemistry/IntegralData/YAML).
+The [Integral/YAML](https://github.com/microsoft/Quantum/tree/master/samples/chemistry/IntegralData/YAML) folder in the Quantum Development Kit Samples repository contains multiple chemical representations defined using the Broombridge schema.


### PR DESCRIPTION
end-to-end.md:
-- fix 404 link errors and minor edits

broombridge.md
-- fix 404 link errors
-- fix generic anchor text instances ("here") and surrounding content as needed
-- Edited the data generation paragraph. The original run-on sentence was hard to interpret - please review to ensure that I didn't alter the intent. 