### PR TITLE
Add article on how to contribute samples

### DIFF
--- a/articles/contributing/code.md
+++ b/articles/contributing/code.md
@@ -133,7 +133,33 @@ Looking at the files that make up each folder, let's dive into the [`algorithms/
 Not all samples will have the exact same set of files (e.g.: some samples may be C#-only, others may not have a Python host, or some samples may require auxillary data files to work).
 One especially important file, though, is the `README.md` file, as that's what users need to get started with your sample!
 
-:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md":::
+Each `README.md` should start with some metadata that helps docs.microsoft.com/samples find your contribution.
+
+> [!div class="nextstepaction"]
+> [See how the chsh-game sample is rendered](https://docs.microsoft.com/samples/microsoft/quantum/validating-quantum-mechanics/)
+
+This metadata is provided as a [YAML header](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html#yaml-header) that indicates what languages your sample covers (typically, this will be `qsharp`, `csharp`, and `python`), and what products your sample covers (typically, just `qdk`).
+
+:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="1-11":::
+
+After that, it's helpful to give a short intro that says what your new sample does:
+
+:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="13-21":::
+
+Users of your sample will also appreciate knowing what they need to run it (e.g.: do users just need the Quantum Development Kit itself, or do they need additional software such as node.js?):
+
+:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="23-25":::
+
+With all that in place, you can tell users how to run your sample:
+
+:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="27-50":::
+
+Finally, it's helpful to tell users what each file in your sample does, and where they can go for more information:
+
+:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="52-61":::
+
+> [!WARNING]
+> Make sure to use absolute URLs here, since your sample will appear at a different URL when rendered at docs.microsoft.com/samples!
 
 <!-- ## Contributing to the Quantum Development Kit Libraries -->
 

--- a/articles/contributing/code.md
+++ b/articles/contributing/code.md
@@ -52,7 +52,7 @@ function PairTest () : Unit {
 More complicated conditions can be checked using the techniques in the [testing section](xref:microsoft.quantum.libraries.diagnostics) of the standard libraries guide.
 For instance, the following test checks that `H(q); X(q); H(q);` as called by <xref:microsoft.quantum.canon.applywith> does the same thing as `Z(q)`.
 
-```qsharp
+```Q#
 @Test("QuantumSimulator")
 operation TestApplyWith() : Unit {
     let actual = ApplyWith(H, X, _);
@@ -94,6 +94,50 @@ In these cases, we'll try to offer some advice in code reviews about what can be
 Finally, we cannot accept contributions that cause harm the quantum computing community, as outlined in the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 We want to ensure that contributions serve the entire quantum computing community, both in its current wonderful diversity, and in the future as it grows to become still more inclusive.
 We appreciate your help in realizing this goal.
+
+## What a Good Sample Looks Like
+
+If you're interested in contributing code to the [samples repository](https://github.com/Microsoft/Quantum), thank you for your contribution to the quantum development community!
+To help you prepare your contribution to help out as much as possible, it's helpful to take a quick look at how the samples repository is laid out:
+
+```plaintext
+microsoft/Quantum
+📁 samples/
+  📁 algorithms/
+    📁 chsh-game/
+      📝 CHSHGame.csproj
+      📝 Game.qs
+      📝 Host.cs
+      📝 host.py
+      📝 README.md
+     ⋮
+  📁 arithmetic/
+  📁 characterization/
+  📁 chemistry/
+   ⋮
+```
+
+That is, the samples in the [microsoft/Quantum repository](https://github.com/microsoft/Quantum) are broken down by subject area into different folders such as `algorithms/`, `arithmetic/`, or `characterization/`.
+Within the folder for each subject area, each sample consists of a single folder that collects everything a user will need to explore and make use of that sample.
+
+Looking at the files that make up each folder, let's dive into the [`algorithms/chsh-game/`](todo:todo) sample.
+
+| File              | Description                                                |
+|-------------------|------------------------------------------------------------|
+| `CHSHGame.csproj` | Q# project used to build the sample with the .NET Core SDK |
+| `Game.qs`         | Q# operations and functions for the sample                 |
+| `Host.cs`         | C# host program used to run the sample                     |
+| `host.py`         | Python host program used to run the sample                 |
+| `README.md`       | Documentation on what the sample does and how to use it    |
+
+Not all samples will have the exact same set of files (e.g.: some samples may be C#-only, others may not have a Python host, or some samples may require auxillary data files to work).
+One especially important file, though, is the `README.md` file, as that's what users need to get started with your sample!
+
+```markdown
+:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md":::
+```
+
+<!-- ## Contributing to the Quantum Development Kit Libraries -->
 
 ## Next steps
 

--- a/articles/contributing/code.md
+++ b/articles/contributing/code.md
@@ -133,9 +133,7 @@ Looking at the files that make up each folder, let's dive into the [`algorithms/
 Not all samples will have the exact same set of files (e.g.: some samples may be C#-only, others may not have a Python host, or some samples may require auxillary data files to work).
 One especially important file, though, is the `README.md` file, as that's what users need to get started with your sample!
 
-```markdown
 :::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md":::
-```
 
 <!-- ## Contributing to the Quantum Development Kit Libraries -->
 

--- a/articles/contributing/code.md
+++ b/articles/contributing/code.md
@@ -95,74 +95,6 @@ Finally, we cannot accept contributions that cause harm the quantum computing co
 We want to ensure that contributions serve the entire quantum computing community, both in its current wonderful diversity, and in the future as it grows to become still more inclusive.
 We appreciate your help in realizing this goal.
 
-## What a Good Sample Looks Like
-
-If you're interested in contributing code to the [samples repository](https://github.com/Microsoft/Quantum), thank you for your contribution to the quantum development community!
-To help you prepare your contribution to help out as much as possible, it's helpful to take a quick look at how the samples repository is laid out:
-
-```plaintext
-microsoft/Quantum
-📁 samples/
-  📁 algorithms/
-    📁 chsh-game/
-      📝 CHSHGame.csproj
-      📝 Game.qs
-      📝 Host.cs
-      📝 host.py
-      📝 README.md
-     ⋮
-  📁 arithmetic/
-  📁 characterization/
-  📁 chemistry/
-   ⋮
-```
-
-That is, the samples in the [microsoft/Quantum repository](https://github.com/microsoft/Quantum) are broken down by subject area into different folders such as `algorithms/`, `arithmetic/`, or `characterization/`.
-Within the folder for each subject area, each sample consists of a single folder that collects everything a user will need to explore and make use of that sample.
-
-Looking at the files that make up each folder, let's dive into the [`algorithms/chsh-game/`](todo:todo) sample.
-
-| File              | Description                                                |
-|-------------------|------------------------------------------------------------|
-| `CHSHGame.csproj` | Q# project used to build the sample with the .NET Core SDK |
-| `Game.qs`         | Q# operations and functions for the sample                 |
-| `Host.cs`         | C# host program used to run the sample                     |
-| `host.py`         | Python host program used to run the sample                 |
-| `README.md`       | Documentation on what the sample does and how to use it    |
-
-Not all samples will have the exact same set of files (e.g.: some samples may be C#-only, others may not have a Python host, or some samples may require auxillary data files to work).
-One especially important file, though, is the `README.md` file, as that's what users need to get started with your sample!
-
-Each `README.md` should start with some metadata that helps docs.microsoft.com/samples find your contribution.
-
-> [!div class="nextstepaction"]
-> [See how the chsh-game sample is rendered](https://docs.microsoft.com/samples/microsoft/quantum/validating-quantum-mechanics/)
-
-This metadata is provided as a [YAML header](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html#yaml-header) that indicates what languages your sample covers (typically, this will be `qsharp`, `csharp`, and `python`), and what products your sample covers (typically, just `qdk`).
-
-:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="1-11":::
-
-After that, it's helpful to give a short intro that says what your new sample does:
-
-:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="13-21":::
-
-Users of your sample will also appreciate knowing what they need to run it (e.g.: do users just need the Quantum Development Kit itself, or do they need additional software such as node.js?):
-
-:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="23-25":::
-
-With all that in place, you can tell users how to run your sample:
-
-:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="27-50":::
-
-Finally, it's helpful to tell users what each file in your sample does, and where they can go for more information:
-
-:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="52-61":::
-
-> [!WARNING]
-> Make sure to use absolute URLs here, since your sample will appear at a different URL when rendered at docs.microsoft.com/samples!
-
-<!-- ## Contributing to the Quantum Development Kit Libraries -->
-
 ## Next steps
 
 Thanks for helping to make the Quantum Development Kit a great resource for the entire quantum programming community!
@@ -170,3 +102,8 @@ To learn more, please continue with the following guide on Q# style.
 
 > [!div class="nextstepaction"]
 > [Learn about Q# style guidelines](xref:microsoft.quantum.contributing.style)
+
+Depending on what kind of code you're contributing, there may be additional things to keep in mind that can help you make your contribution do as much good for the community as possible.
+
+> [!div class="nextstepaction"]
+> [Learn about contributing samples](xref:microsoft.quantum.contributing.samples)

--- a/articles/contributing/code.md
+++ b/articles/contributing/code.md
@@ -8,20 +8,20 @@ ms.topic: article
 uid: microsoft.quantum.contributing.code
 ---
 
-# Contributing Code #
+# Contributing Code
 
 In addition to reporting issues and improving documentation, contributing code to the Quantum Development Kit can be a very direct way to help your peers in the quantum programming community.
 By contributing code, you can help to fix issues, provide new examples, make existing libraries easier to use, or even add entirely new features.
 
 In this guide, we'll detail a bit of what we look for when we review pull requests to help your contribution do the most good.
 
-## What We Look For ##
+## What We Look For
 
 An ideal code contribution builds on the existing work in a Quantum Development Kit repository to fix issues, expand existing features, or to add new features that are within the scope of a repository.
 When we accept a code contribution, it becomes a part of the Quantum Development Kit itself, such that new features will be released, maintained, and developed in the same way as the rest of the Quantum Development Kit.
 Thus, it is helpful when functionality added by a contribution is well-tested and is documented.
 
-### Unit Tests ###
+### Unit Tests
 
 The Q# functions, operations, and user-defined types that make up libraries such as the canon are automatically tested as a part of development on the [**Microsoft/QuantumLibraries**](https://github.com/Microsoft/QuantumLibraries/) repository.
 When a new pull request is opened, for instance, our [Azure Pipelines](https://azure.microsoft.com/services/devops/pipelines/) configuration will check that the changes in the pull request do not break any existing functionality that the quantum programming community depends on.
@@ -75,7 +75,8 @@ Locally, unit tests can be run using the Visual Studio Test Explorer or the `dot
 
 ### Citations and References ### -->
 
-## When We'll Reject a Pull Request ##
+
+## When We'll Reject a Pull Request
 
 Sometimes, we'll reject the pull request for a contribution.
 If this happens to you, it doesn't mean that it's bad, as there's a number of reasons why we might not be able to accept a particular contribution.
@@ -94,7 +95,7 @@ Finally, we cannot accept contributions that cause harm the quantum computing co
 We want to ensure that contributions serve the entire quantum computing community, both in its current wonderful diversity, and in the future as it grows to become still more inclusive.
 We appreciate your help in realizing this goal.
 
-## Next steps ##
+## Next steps
 
 Thanks for helping to make the Quantum Development Kit a great resource for the entire quantum programming community!
 To learn more, please continue with the following guide on Q# style.

--- a/articles/contributing/docs.md
+++ b/articles/contributing/docs.md
@@ -8,7 +8,7 @@ ms.topic: article
 uid: microsoft.quantum.contributing.docs
 ---
 
-# Improving Documentation #
+# Improving Documentation
 
 The documentation for the Quantum Development Kit takes on several different forms, such that information is readily available to quantum developers.
 
@@ -23,7 +23,7 @@ That said, each form of documentation does vary somewhat in the details:
 - The **API reference** is a set of pages for each Q# function, operation, and user-defined type, published to https://docs.microsoft.com/qsharp/api/. These pages document the inputs and operations to each callable, along with examples and links to more information. The API reference is automatically extracted from small DFM documents in Q# source code as a part of each release.
 - The **README<!---->.md** files included with each sample and kata describe how to use that sample or kata is used, what it covers, and how it relates to the rest of the Quantum Development Kit. These files are written using [GitHub Flavored Markdown (GFM)](https://github.github.com/gfm/), a more lightweight alternative to DFM that's popular for attaching documentation directly to code repositories.
 
-## Contributing to the Conceptual Documentation ##
+## Contributing to the Conceptual Documentation
 
 To contribute an improvement to the conceptual or README documentation, then, starts with a pull request onto either [**MicrosoftDocs/quantum-docs-pr**](https://github.com/MicrosoftDocs/quantum-docs-pr/
 ), [**Microsoft/Quantum**](https://github.com/Microsoft/Quantum), or [**Microsoft/QuantumKatas**](https://github.com/Microsoft/QuantumKatas), as is appropriate.
@@ -36,7 +36,18 @@ We'll describe more about pull requests below, but for now there's a few things 
 - Many members of the quantum programming community are academic researchers, and are recognized mainly through citations for their contributions to the community. In addition to helping readers find additional materials, making sure to properly cite academic outputs such as papers, talks, blog posts, and software tools can help academic contributors to keep doing their best work to improve the community.
 - The quantum programming community is a broad and wonderfully diverse community. The use of gendered pronouns in third-person examples (e.g.: "if a user ..., he will ...") can work to exclude rather than include. Being cognizant of people's names in citations and links, and of the correct inclusion of non-ASCII characters can serve the diversity of the community by showing respect to its members. Similarly, many words in the English language are often used in a hateful manner, such that their use in technical documentation can cause harm both to individual readers and to the community at large.
 
-## Contributing to the API References ##
+### Referencing Sample Code from Conceptual Articles
+
+If you want to include code from the [samples repository](https://github.com/Microsoft/Quantum), you can do so using a special DocFX-Flavored Markdown command:
+
+```markdown
+:::code language="qsharp" source="~/quantum/samples/algorithms/chsh-game/Game.qs" range="4-8":::
+```
+
+This command will import lines 4 to 8 of the [`Game.qs` file from the `chsh-game` sample](https://github.com/microsoft/Quantum/blob/master/samples/algorithms/chsh-game/Game.qs), marking them as Q# code for the purpose of syntax highlighting.
+Using this command, you can avoid duplicating code between conceptual articles and the samples repository, so that sample code in documentation is always as up to date as possible.
+
+## Contributing to the API References
 
 To contribute an improvement to the API references, it's most helpful to open a pull request directly on the code being documented.
 Each function, operation, or user-defined type supports a documentation comment (denoted with `///` instead of `//`).
@@ -118,6 +129,7 @@ For the example of `ControlledOnBitString`, we might write something like the fo
      return ControlledOnBitStringImpl(bits, oracle, _, _);
  }
 ```
+
 You can see the rendered version of the code above in the [API documentation for the `ControlledOnBitString` function](xref:microsoft.quantum.canon.controlledonbitstring).
 
 In addition to the general practice of documentation writing, in writing API documentation comments it helps to keep a few things in mind:

--- a/articles/contributing/index.md
+++ b/articles/contributing/index.md
@@ -8,7 +8,7 @@ ms.topic: article
 uid: microsoft.quantum.contributing
 ---
 
-# Contributing to the Quantum Development Kit #
+# Contributing to the Quantum Development Kit
 
 The Quantum Development Kit is more than a collection of tools for writing quantum programs.
 It's part of a broad community of people discovering quantum computing, performing research in quantum algorithms, developing new applications for quantum devices, and otherwise working to make the most out of the quantum programming.
@@ -18,7 +18,7 @@ We're very thankful for your kind contributions, and for the opportunity to work
 
 In this guide, we provide some advice on how to make your contribution as useful as possible to the broader quantum programming community.
 
-## Building Community ##
+## Building Community
 
 The very first thing about making a contribution is to always keep in mind the community that you are contributing to.
 By acting respectfully and professionally towards your peers in the quantum programming community and more broadly, you can help to make sure that your efforts build the best and most welcoming community possible.
@@ -27,7 +27,7 @@ As a part of that effort, all Quantum Development Kit projects have adopted the 
 For more information, please see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-## What Kinds of Contributions Help the Community? ##
+## What Kinds of Contributions Help the Community?
 
 There are lots of different ways to help the quantum programming community through your contributions.
 In this guide, we'll focus on three ways that are especially relevant to the Quantum Development Kit.
@@ -41,7 +41,7 @@ That said, this is definitely not an exhaustive list — we encourage you to exp
 These different kinds of contributions are all immensely valuable, and are greatly appreciated.
 In the rest of the guide, we'll offer advice on how to make each kind of contribution.
 
-## Where Do Contributions Go? ##
+## Where Do Contributions Go?
 
 The Quantum Development Kit includes a number of different pieces that all work together to realize a platform for writing quantum programs.
 Each of these different pieces finds its home on a different repository, so the one of the earlier things to sort out is where each contribution best belongs.
@@ -62,7 +62,7 @@ There are also a few other, more specialized repositories focusing on different 
 - [**msr-quarc/qsharp.sty**](https://github.com/msr-quarc/qsharp.sty): LaTeX formatting support for Q# syntax.
 - [**msr-quarc/intern-workshop-2019**](https://github.com/msr-quarc/intern-workshop-2019): IQ# Notebook for Deutsch–Jozsa tutorial given at the 2019 intern workshop.
 
-## Next steps ##
+## Next steps
 
 Thanks for being a part of the Quantum Development Kit community, we're excited for your contributions!
 If you'd like to learn more about contributing, please continue with one of the following guides.

--- a/articles/contributing/samples.md
+++ b/articles/contributing/samples.md
@@ -1,0 +1,83 @@
+---
+title: Contributing samples to the Microsoft QDK
+description: Learn how to contribute sample code to the Microsoft Quantum Development Kit (QDK).
+author: cgranade
+ms.author: chgranad
+ms.date: 10/12/2018
+ms.topic: article
+uid: microsoft.quantum.contributing.samples
+---
+
+# Contributing Samples to the Quantum Development Kit
+
+If you're interested in contributing code to the [samples repository](https://github.com/Microsoft/Quantum), thank you for making the quantum development community a better place!
+
+## The Quantum Development Kit Samples Repository
+
+To help you prepare your contribution to help out as much as possible, it's helpful to take a quick look at how the samples repository is laid out:
+
+```plaintext
+microsoft/Quantum
+📁 samples/
+  📁 algorithms/
+    📁 chsh-game/
+      📝 CHSHGame.csproj
+      📝 Game.qs
+      📝 Host.cs
+      📝 host.py
+      📝 README.md
+     ⋮
+  📁 arithmetic/
+  📁 characterization/
+  📁 chemistry/
+   ⋮
+```
+
+That is, the samples in the [microsoft/Quantum repository](https://github.com/microsoft/Quantum) are broken down by subject area into different folders such as `algorithms/`, `arithmetic/`, or `characterization/`.
+Within the folder for each subject area, each sample consists of a single folder that collects everything a user will need to explore and make use of that sample.
+
+## How Samples are Structured
+
+Looking at the files that make up each folder, let's dive into the [`algorithms/chsh-game/`](todo:todo) sample.
+
+| File              | Description                                                |
+|-------------------|------------------------------------------------------------|
+| `CHSHGame.csproj` | Q# project used to build the sample with the .NET Core SDK |
+| `Game.qs`         | Q# operations and functions for the sample                 |
+| `Host.cs`         | C# host program used to run the sample                     |
+| `host.py`         | Python host program used to run the sample                 |
+| `README.md`       | Documentation on what the sample does and how to use it    |
+
+Not all samples will have the exact same set of files (e.g.: some samples may be C#-only, others may not have a Python host, or some samples may require auxillary data files to work).
+
+## Anatomy of a Helpful README File
+
+One especially important file, though, is the `README.md` file, as that's what users need to get started with your sample!
+
+Each `README.md` should start with some metadata that helps docs.microsoft.com/samples find your contribution.
+
+> [!div class="nextstepaction"]
+> [See how the chsh-game sample is rendered](https://docs.microsoft.com/samples/microsoft/quantum/validating-quantum-mechanics/)
+
+This metadata is provided as a [YAML header](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html#yaml-header) that indicates what languages your sample covers (typically, this will be `qsharp`, `csharp`, and `python`), and what products your sample covers (typically, just `qdk`).
+
+:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="1-11":::
+
+After that, it's helpful to give a short intro that says what your new sample does:
+
+:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="13-21":::
+
+Users of your sample will also appreciate knowing what they need to run it (e.g.: do users just need the Quantum Development Kit itself, or do they need additional software such as node.js?):
+
+:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="23-25":::
+
+With all that in place, you can tell users how to run your sample:
+
+:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="27-50":::
+
+Finally, it's helpful to tell users what each file in your sample does, and where they can go for more information:
+
+:::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="52-61":::
+
+> [!WARNING]
+> Make sure to use absolute URLs here, since your sample will appear at a different URL when rendered at docs.microsoft.com/samples!

--- a/articles/contributing/samples.md
+++ b/articles/contributing/samples.md
@@ -63,6 +63,10 @@ This metadata is provided as a [YAML header](https://dotnet.github.io/docfx/spec
 
 :::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="1-11":::
 
+> [!IMPORTANT]
+> The `page_type: sample` key in the header is required for your sample to appear at docs.microsoft.com/samples.
+> Similarly, the `product` and `language` keys are critical for helping users to find and run your sample.
+
 After that, it's helpful to give a short intro that says what your new sample does:
 
 :::code language="markdown" source="~/quantum/samples/algorithms/chsh-game/README.md" range="13-21":::

--- a/articles/contributing/samples.md
+++ b/articles/contributing/samples.md
@@ -38,7 +38,7 @@ Within the folder for each subject area, each sample consists of a single folder
 
 ## How Samples are Structured
 
-Looking at the files that make up each folder, let's dive into the [`algorithms/chsh-game/`](todo:todo) sample.
+Looking at the files that make up each folder, let's dive into the [`algorithms/chsh-game/`](https://github.com/microsoft/Quantum/tree/master/samples/algorithms/chsh-game) sample.
 
 | File              | Description                                                |
 |-------------------|------------------------------------------------------------|

--- a/articles/contributing/toc.yml
+++ b/articles/contributing/toc.yml
@@ -6,5 +6,7 @@
   href: pull-requests.md
 - name: Contributing Code
   href: code.md
+- name: Contributing Samples
+  href: samples.md
 - name: Style Guide
   href: style-guide.md


### PR DESCRIPTION
As we continue standardizing sample layouts and onboarding Quantum Development Kit samples to the [Samples Browser](docs.microsoft.com/samples), it will be helpful to document how we write samples and what content needs to be there for working with the Samples Browser. This PR begins that effort by documenting what I look for as I port samples to that format and prepare them for publication at docs.microsoft.com/samples.