### PR TITLE
update redirects for names changes and deletions

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -53,7 +53,7 @@
         },
         {
             "source_path": "articles/quantum-concepts-9-SoftwareStack.md",
-            "redirect_url": "concepts/software-stack",
+            "redirect_url": "concepts/",
             "redirect_document_id": true
         },
         {
@@ -208,33 +208,38 @@
         },
         {
             "source_path": "articles/install-guide/command-line.md",
-            "redirect_url": "/quantum/install-guide",
+            "redirect_url": "index",
             "redirect_document_id": false
         },
         {
             "source_path": "articles/install-guide/csharp.md",
-            "redirect_url": "/quantum/install-guide",
+            "redirect_url": "csinstall",
             "redirect_document_id": false
         },
         {
             "source_path": "articles/install-guide/jupyter.md",
-            "redirect_url": "/quantum/install-guide",
+            "redirect_url": "qjupyter",
             "redirect_document_id": false
         },
         {
             "source_path": "articles/install-guide/python.md",
-            "redirect_url": "/quantum/install-guide",
+            "redirect_url": "pyinstall",
             "redirect_document_id": false
         },
         {
             "source_path": "articles/install-guide/vs-2017.md",
-            "redirect_url": "/quantum/install-guide",
+            "redirect_url": "index",
             "redirect_document_id": true
         },
         {
             "source_path": "articles/install-guide/vs-code.md",
-            "redirect_url": "/quantum/install-guide",
+            "redirect_url": "index",
             "redirect_document_id": false
+        },
+        {
+            "source_path": "articles/Glossary.md",
+            "redirect_url": "concepts/glossary",
+            "redirect_document_id": true
         }
     ]
 }

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -53,7 +53,7 @@
         },
         {
             "source_path": "articles/quantum-concepts-9-SoftwareStack.md",
-            "redirect_url": "concepts/",
+            "redirect_url": "/quantum/concepts/",
             "redirect_document_id": true
         },
         {
@@ -208,37 +208,37 @@
         },
         {
             "source_path": "articles/install-guide/command-line.md",
-            "redirect_url": "index",
+            "redirect_url": "/quantum/install-guide/csinstall",
             "redirect_document_id": false
         },
         {
             "source_path": "articles/install-guide/csharp.md",
-            "redirect_url": "csinstall",
+            "redirect_url": "/quantum/install-guide/csinstall",
             "redirect_document_id": false
         },
         {
             "source_path": "articles/install-guide/jupyter.md",
-            "redirect_url": "qjupyter",
+            "redirect_url": "/quantum/install-guide/qjupyter",
             "redirect_document_id": false
         },
         {
             "source_path": "articles/install-guide/python.md",
-            "redirect_url": "pyinstall",
+            "redirect_url": "/quantum/install-guide/pyinstall",
             "redirect_document_id": false
         },
         {
             "source_path": "articles/install-guide/vs-2017.md",
-            "redirect_url": "index",
+            "redirect_url": "/quantum/install-guide/csinstall",
             "redirect_document_id": true
         },
         {
             "source_path": "articles/install-guide/vs-code.md",
-            "redirect_url": "index",
+            "redirect_url": "/quantum/install-guide/csinstall",
             "redirect_document_id": false
         },
         {
             "source_path": "articles/Glossary.md",
-            "redirect_url": "concepts/glossary",
+            "redirect_url": "/quantum/concepts/glossary",
             "redirect_document_id": true
         }
     ]


### PR DESCRIPTION
Moved (and name change):
articles/Glossary.md -> articles/concepts/glossary.md

Name change:
install-guide/python.md -> pyinstall.md
install-guide/csharp.md -> csinstall.md
install-guide/jupyter.md -> qjupyter.md

Deleted:
install-guide/vs-2017.md -> /install-guide/csinstall.md
install-guide/vs-code.md -> /install-guide/csinstall.md
install-guide/command-line.md -> /install-guide/csinstall.md
articles/concepts/software-stack.md -> /concepts