### PR TITLE
Add example of errors when using internal UDTs in public signatures

### DIFF
--- a/articles/language/file-structure.md
+++ b/articles/language/file-structure.md
@@ -398,10 +398,11 @@ An internal user-defined type, operation, or function can be declared simply by 
 For example,
 
 ```qsharp
-internal newtype PairOfInts = (Int, Int);
+internal newtype PairOfQubits = (Qubit, Qubit);
 
-internal operation PrepareEntangledPair(q1 : Qubit, q2 : Qubit) : Unit 
+internal operation PrepareEntangledPair(pair : PairOfQubits) : Unit 
 is Adj + Ctl {
+    let (q1, q2) = pair!;
     H(q2);
     CNOT(q2, q1);
 }

--- a/articles/language/file-structure.md
+++ b/articles/language/file-structure.md
@@ -399,7 +399,8 @@ Internal declarations are useful for writing modular code that can be reused by 
 > They can only be used in signatures or underlying types if the corresponding callable or user-defined type is also internal.
 >
 > For example, if a UDT `InternalOptions` is defined with the `internal` keyword, then the following declarations will result in errors:
-> ```Q#
+>
+> ```qsharp
 > function DefaultInternalOptions() : InternalOptions { ... } // error: can't use InternalOptions as an output type
 > newtype ExtendedOptions = (Internal : InternalOptions); // error: can't use InternalOptions as an item
 > ```

--- a/articles/language/file-structure.md
+++ b/articles/language/file-structure.md
@@ -412,14 +412,12 @@ internal function DotProduct(a : Double[], b : Double[]) : Double {
 ```
 
 > [!WARNING]
-> Internal user-defined types cannot be used in the signatures of public callables, or in the underlying types of public user-defined types.
-> They can only be used in signatures or underlying types if the corresponding callable or user-defined type is also internal.
->
+> Internal user-defined types can only be used in signatures or underlying types if the corresponding callable or user-defined type is also internal.
 > For example, if there is a user-defined type `InternalOptions` that was declared with the `internal` keyword, then the following declarations will result in errors:
 >
 > ```qsharp
-> // Error: Can't use InternalOptions as an output type.
+> // Error: Can't use InternalOptions as an output type of a public function.
 > function DefaultInternalOptions() : InternalOptions { ... }
-> // Error: Can't use InternalOptions as an item.
+> // Error: Can't use InternalOptions as an item in a public user-defined type.
 > newtype ExtendedOptions = (Internal : InternalOptions);
 > ```

--- a/articles/language/file-structure.md
+++ b/articles/language/file-structure.md
@@ -398,7 +398,7 @@ Internal declarations are useful for writing modular code that can be reused by 
 > Internal user-defined types cannot be used in the signatures of public callables, or in the underlying types of public user-defined types.
 > They can only be used in signatures or underlying types if the corresponding callable or user-defined type is also internal.
 >
-> For example, if a UDT `InternalOptions` is defined with the `internal` keyword, then the following declarations will result in errors:
+> For example, if there is a user-defined type `InternalOptions` that was declared with the `internal` keyword, then the following declarations will result in errors:
 >
 > ```qsharp
 > // Error: Can't use InternalOptions as an output type.

--- a/articles/language/file-structure.md
+++ b/articles/language/file-structure.md
@@ -395,7 +395,7 @@ When a project is used as a reference, all of its *public* (non-internal) declar
 Internal declarations are useful for writing modular code that can be reused by other parts of your project, but still be changed later without breaking other projects that might depend on it.
 
 > [!WARNING]
-> Internal user-defined types cannot be used in the signatures of public callables or in the underlying types of public user-defined types.
+> Internal user-defined types cannot be used in the signatures of public callables, or in the underlying types of public user-defined types.
 > They can only be used in signatures or underlying types if the corresponding callable or user-defined type is also internal.
 
 An internal user-defined type, operation, or function can be declared simply by adding `internal` at the beginning of the declaration.

--- a/articles/language/file-structure.md
+++ b/articles/language/file-structure.md
@@ -397,6 +397,12 @@ Internal declarations are useful for writing modular code that can be reused by 
 > [!WARNING]
 > Internal user-defined types cannot be used in the signatures of public callables, or in the underlying types of public user-defined types.
 > They can only be used in signatures or underlying types if the corresponding callable or user-defined type is also internal.
+>
+> For example, if a UDT `InternalOptions` is defined with the `internal` keyword, then the following declarations will result in errors:
+> ```Q#
+> function DefaultInternalOptions() : InternalOptions { ... } // error: can't use InternalOptions as an output type
+> newtype ExtendedOptions = (Internal : InternalOptions); // error: can't use InternalOptions as an item
+> ```
 
 An internal user-defined type, operation, or function can be declared simply by adding `internal` at the beginning of the declaration.
 For example,

--- a/articles/language/file-structure.md
+++ b/articles/language/file-structure.md
@@ -418,6 +418,7 @@ internal function DotProduct(a : Double[], b : Double[]) : Double {
 > ```qsharp
 > // Error: Can't use InternalOptions as an output type of a public function.
 > function DefaultInternalOptions() : InternalOptions { ... }
+>
 > // Error: Can't use InternalOptions as an item in a public user-defined type.
 > newtype ExtendedOptions = (Internal : InternalOptions);
 > ```

--- a/articles/language/file-structure.md
+++ b/articles/language/file-structure.md
@@ -401,8 +401,10 @@ Internal declarations are useful for writing modular code that can be reused by 
 > For example, if a UDT `InternalOptions` is defined with the `internal` keyword, then the following declarations will result in errors:
 >
 > ```qsharp
-> function DefaultInternalOptions() : InternalOptions { ... } // error: can't use InternalOptions as an output type
-> newtype ExtendedOptions = (Internal : InternalOptions); // error: can't use InternalOptions as an item
+> // Error: Can't use InternalOptions as an output type.
+> function DefaultInternalOptions() : InternalOptions { ... }
+> // Error: Can't use InternalOptions as an item.
+> newtype ExtendedOptions = (Internal : InternalOptions);
 > ```
 
 An internal user-defined type, operation, or function can be declared simply by adding `internal` at the beginning of the declaration.

--- a/articles/language/file-structure.md
+++ b/articles/language/file-structure.md
@@ -394,19 +394,6 @@ This means that they can only be accessed from within the Q# project that they a
 When a project is used as a reference, all of its *public* (non-internal) declarations are made available, but trying to use an internal declaration from another project will produce an error.
 Internal declarations are useful for writing modular code that can be reused by other parts of your project, but still be changed later without breaking other projects that might depend on it.
 
-> [!WARNING]
-> Internal user-defined types cannot be used in the signatures of public callables, or in the underlying types of public user-defined types.
-> They can only be used in signatures or underlying types if the corresponding callable or user-defined type is also internal.
->
-> For example, if there is a user-defined type `InternalOptions` that was declared with the `internal` keyword, then the following declarations will result in errors:
->
-> ```qsharp
-> // Error: Can't use InternalOptions as an output type.
-> function DefaultInternalOptions() : InternalOptions { ... }
-> // Error: Can't use InternalOptions as an item.
-> newtype ExtendedOptions = (Internal : InternalOptions);
-> ```
-
 An internal user-defined type, operation, or function can be declared simply by adding `internal` at the beginning of the declaration.
 For example,
 
@@ -423,3 +410,16 @@ internal function DotProduct(a : Double[], b : Double[]) : Double {
     ...
 }
 ```
+
+> [!WARNING]
+> Internal user-defined types cannot be used in the signatures of public callables, or in the underlying types of public user-defined types.
+> They can only be used in signatures or underlying types if the corresponding callable or user-defined type is also internal.
+>
+> For example, if there is a user-defined type `InternalOptions` that was declared with the `internal` keyword, then the following declarations will result in errors:
+>
+> ```qsharp
+> // Error: Can't use InternalOptions as an output type.
+> function DefaultInternalOptions() : InternalOptions { ... }
+> // Error: Can't use InternalOptions as an item.
+> newtype ExtendedOptions = (Internal : InternalOptions);
+> ```


### PR DESCRIPTION
This adds @cgranade's suggestions from PR #755.

(Making this a draft to see if I can get a preview build first, to make sure the code block looks OK.)