### PR TITLE
Fix condition in Fact example for positive number

### DIFF
--- a/articles/techniques/testing-and-debugging.md
+++ b/articles/techniques/testing-and-debugging.md
@@ -157,7 +157,7 @@ Thus, if we proceed past a call to `PositivityFact`, we can be assured by that i
 Note that we can implement the same behavior as `PositivityFact` using the [`Fact`](xref:microsoft.quantum.diagnostics.fact) function from the <xref:microsoft.quantum.diagnostics> namespace:
 
 ```qsharp
-	Fact(value <= 0, "Expected a positive number.");
+    Fact(value > 0, "Expected a positive number.");
 ```
 
 *Assertions*, on the other hand, are used similarly to facts, but may be dependent on the state of the target machine. 


### PR DESCRIPTION
The first argument to Fact is condition that should hold, not condition that causes the code to fail, so the comparison should be opposite to the previous example