### PR TITLE
Set samples branch back to master

### DIFF
--- a/.github/workflows/check-samples-branch.yml
+++ b/.github/workflows/check-samples-branch.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Check that samples branch refers to master.
         run: |
+          Get-ChildItem | Write-Host;
+          Get-Location | Write-Host;
           $configPath = ".openpublishing.publish.config.json";
           $config = Get-Content $configPath | ConvertFrom-Json;
           $samplesRepo = $config.dependent_repositories | Where-Object {

--- a/.github/workflows/check-samples-branch.yml
+++ b/.github/workflows/check-samples-branch.yml
@@ -1,0 +1,20 @@
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  check-samples-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check that samples branch refers to master.
+        run: |
+          $configPath = ".openpublishing.publish.config.json";
+          $config = Get-Content $configPath | ConvertFrom-Json;
+          $samplesRepo = $config.dependent_repositories | Where-Object {
+            $_.url -eq "https://github.com/microsoft/quantum"
+          }
+          if ($samplesRepo.branch -ne "master") {
+            Write-Host "::error file=$configPath::Samples repository branch is not set to master for a PR targeting master."
+          }
+        shell: pwsh

--- a/.github/workflows/check-samples-branch.yml
+++ b/.github/workflows/check-samples-branch.yml
@@ -7,6 +7,7 @@ jobs:
   check-samples-branch:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Check that samples branch refers to master.
         run: |
           Get-ChildItem | Write-Host;

--- a/.github/workflows/check-samples-branch.yml
+++ b/.github/workflows/check-samples-branch.yml
@@ -19,5 +19,6 @@ jobs:
           }
           if ($samplesRepo.branch -ne "master") {
             Write-Host "::error file=$configPath::Samples repository branch is not set to master for a PR targeting master."
+            exit 1;
           }
         shell: pwsh

--- a/.github/workflows/check-samples-branch.yml
+++ b/.github/workflows/check-samples-branch.yml
@@ -10,8 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check that samples branch refers to master.
         run: |
-          Get-ChildItem | Write-Host;
-          Get-Location | Write-Host;
           $configPath = ".openpublishing.publish.config.json";
           $config = Get-Content $configPath | ConvertFrom-Json;
           $samplesRepo = $config.dependent_repositories | Where-Object {

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -72,7 +72,7 @@
     {
       "path_to_root": "articles/quantum",
       "url": "https://github.com/microsoft/quantum",
-      "branch": "feature/standalone",
+      "branch": "master",
       "branch_mapping": {}
     }
   ],


### PR DESCRIPTION
This PR resets the branch used to include code samples back to master in preparation for merging feature/standalone to master, and adds a new GitHub Action that flags when the branch is not set correctly.