### PR TITLE
Small fixes (TOC and Update page)

### DIFF
--- a/articles/TOC.yml
+++ b/articles/TOC.yml
@@ -20,8 +20,6 @@
     href: install-guide/toc.yml
   - name: Update the QDK
     href: install-guide/update.md
-  - name: How to create a Q# project
-    href: how-to-guides/create-qsharp-project.md
 - name: Tutorials
   items:
   - name: Quantum random number generator

--- a/articles/install-guide/update.md
+++ b/articles/install-guide/update.md
@@ -37,11 +37,11 @@ Regardless of whether you are using C# or Python to host Q# operations, follow t
 1. Update to the latest version of Visual Studio 2019, see [here](https://docs.microsoft.com/visualstudio/install/update-visual-studio?view=vs-2019) for instructions
 2. Open your solution in Visual Studio
 3. From the menu, select **Build** -> **Clean Solution**
-4. In each of your .csproj files, update the target framework to `netcoreapp3.0` (or `netstandard2.1` if it is a library project).
+4. In each of your .csproj files, update the target framework to `netcoreapp3.1` (or `netstandard2.1` if it is a library project).
     That is, edit lines of the form:
 
     ```xml
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     ```
 
     You can find more details on specifying target frameworks [here](https://docs.microsoft.com/dotnet/standard/frameworks#how-to-specify-target-frameworks).
@@ -74,11 +74,11 @@ You can now skip ahead to [update your Visual Studio QDK extension](#update-visu
     dotnet clean [project_name].csproj
     ```
 
-3. In each of your .csproj files, update the target framework to `netcoreapp3.0` (or `netstandard2.1` if it is a library project).
+3. In each of your .csproj files, update the target framework to `netcoreapp3.1` (or `netstandard2.1` if it is a library project).
     That is, edit lines of the form:
 
     ```xml
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     ```
 
     You can find more details on specifying target frameworks [here](https://docs.microsoft.com/dotnet/standard/frameworks#how-to-specify-target-frameworks).


### PR DESCRIPTION
Hides "How to create a Q# project" from TOC (it's outdated to the point of causing confusion, and will be subsumed by coming pages anyway)

On Update page, changed `netcoreapp3.0` to `netcoreapp3.1`