### PR TITLE
Small fixes noticed

### DIFF
--- a/articles/install-guide/toc.yml
+++ b/articles/install-guide/toc.yml
@@ -3,7 +3,7 @@ items:
   href: index.md
 - name: Q# command line applications
   href: standalone.md
-- name: Q# Jupyter notebooks
+- name: Q# Jupyter Notebooks
   href: qjupyter.md
 - name: Q# with other languages
   items:

--- a/articles/libraries/toc.yml
+++ b/articles/libraries/toc.yml
@@ -1,3 +1,5 @@
+- name: Overview
+  href: index.md
 - name: Standard libraries
   topicHref: standard/index.md
   href: standard/toc.yml


### PR DESCRIPTION
- Brad had made a very helpful libraries overview page (which we link to from pages), but it didn't make it into the TOC. Added it to the `libraries/toc.yml`

- Capitalized the N in "Q# Jupyter Notebooks" in TOC (I'm pretty sure this a must)