### PR TITLE
Clarify .NET Core SDK version requirement

### DIFF
--- a/articles/install-guide/qjupyter.md
+++ b/articles/install-guide/qjupyter.md
@@ -23,7 +23,7 @@ IQ# (pronounced i-q-sharp) is an extension primarily used by Jupyter and Python 
 
     - [Python](https://www.python.org/downloads/) 3.6 or later
     - [Jupyter Notebook](https://jupyter.readthedocs.io/en/latest/install.html)
-    - [.NET Core SDK 3.1 or later](https://www.microsoft.com/net/download)
+    - [.NET Core SDK 3.1](https://dotnet.microsoft.com/download/dotnet-core/3.1)
 
 1. Install the `iqsharp` package
 


### PR DESCRIPTION
Updating the IQ# installation guide to clarify the .NET Core SDK version requirement (only 3.1 is currently supported) and provide a link directly to the .NET Core 3.1 downloads page, rather than the generic .NET downloads page.