### PR TITLE
Removed links to "how to create a Q# project" page

### DIFF
--- a/articles/libraries/machine-learning/basic-classification.md
+++ b/articles/libraries/machine-learning/basic-classification.md
@@ -17,7 +17,7 @@ In this guide we will use the half-moon dataset, using a classifier structure de
 ## Prerequisites
 
 - The Microsoft [Quantum Development Kit](xref:microsoft.quantum.install).
-- [Create a Q# Project](xref:microsoft.quantum.howto.createproject)
+- Create a Q# project for either a [Python host program](xref:microsoft.quantum.install.python) or a [C# host program](xref:microsoft.quantum.install.cs).
 
 ## Host program
 

--- a/articles/quickstarts/qrng.md
+++ b/articles/quickstarts/qrng.md
@@ -15,7 +15,7 @@ A simple example of a quantum algorithm written in Q# is a quantum random number
 ## Prerequisites
 
 - The Microsoft [Quantum Development Kit](xref:microsoft.quantum.install).
-- [Create a Q# Project](xref:microsoft.quantum.howto.createproject)
+- Create a Q# project for either [using Q# from the command line](xref:microsoft.quantum.install.standalone), or with a [Python host program](xref:microsoft.quantum.install.python) or [C# host program](xref:microsoft.quantum.install.cs).
 
 ## Write a Q# operation
 

--- a/articles/quickstarts/search.md
+++ b/articles/quickstarts/search.md
@@ -34,7 +34,7 @@ The number of incremental boosts is fewer than the number of items in the list. 
 
 ## Write the code
 
-1. Using the Quantum Development Kit, [create a new Q# project](xref:microsoft.quantum.howto.createproject) called `Grover` in your development environment of choice.
+1. Using the Quantum Development Kit, [create a new Q# project for the command line application](xref:microsoft.quantum.install.standalone). Title the project `Grover`.
 
 1. Add the following code to the `Program.qs` file in your new project:
 


### PR DESCRIPTION
We removed [the page](https://docs.microsoft.com/en-us/quantum/how-to-guides/create-qsharp-project) from the TOC as it had been superseded by the instructions on the individual install pages, but it appears we forgot to remove the links to the page from other pages (e.g. the quickstarts and one of the machine learning pages). Hence people are still being sent there under the assumption it is up-to-date info (see issue #872). 

This PR replaced the links with those to the proper pages as a stop-gap, so should be merged ASAP. For a future PR, though, I think we should make a decision on what to do with the file (e.g. move to add redirects and delete the file entirely).