### PR TITLE
Remove TrainWineModel from basic classifier cods

### DIFF
--- a/articles/libraries/machine-learning/basic-classification.md
+++ b/articles/libraries/machine-learning/basic-classification.md
@@ -81,7 +81,7 @@ We save the following code in a file named `Training.qs`.
 The most important functions and operations defined in the code above are:
 
 - `ClassifierStructure() : ControlledRotation[]` : in this function we set the structure of our circuit model by adding the layers of the controlled gates we consider. This step is analogous to the declaration of layers of neurons in a sequential deep learning model.
-- `TrainHalfMoonModel() : TrainWineModel() : (Double[], Double)` : this operation is the core part of the code and defines the training. Here we load the samples from the dataset included in the library, we set the hyper parameters and the initial parameters for the training and we start the training by calling the operation `TrainSequentialClassifier` included in the library. It outputs the parameters and the bias that determine the classifier.
+- `TrainHalfMoonModel() : (Double[], Double)` : this operation is the core part of the code and defines the training. Here we load the samples from the dataset included in the library, we set the hyper parameters and the initial parameters for the training and we start the training by calling the operation `TrainSequentialClassifier` included in the library. It outputs the parameters and the bias that determine the classifier.
 - `ValidateHalfMoonModel(parameters : Double[], bias : Double) : Int` : this operation defines the validation process to evaluate the model. Here we load the samples for validation, the number of measurements per sample and the tolerance. It outputs the number of misclassifications on the chosen batch of samples for validation.
 
 ## Next steps


### PR DESCRIPTION
TrainWineModel() is not part of the code example and can confuse the reader.