### PR TITLE
Remove "bash" grammar where not applicable

### DIFF
--- a/articles/how-to-guides/create-qsharp-project.md
+++ b/articles/how-to-guides/create-qsharp-project.md
@@ -57,13 +57,13 @@ Choose your development environment and language from the sections below:
 
 1. Run the program:
 
-    ```bash
+    ```
     python host.py
     ```
 
 1. Verify the output. Your program should output the following lines:
 
-    ```bash
+    ```
     Hello from quantum world!
     0
     ```
@@ -78,7 +78,7 @@ You can now continue to develop your quantum program.
 
 1. Run the following command to start the notebook server:
 
-    ```bash
+    ```
     jupyter notebook
     ```
 
@@ -174,7 +174,7 @@ You can now continue your quantum development using Visual Studio Code.
 
 1. Navigate to the new application directory
 
-    ```bash
+    ```
     cd <project name>
     ```
 

--- a/articles/install-guide/pyinstall.md
+++ b/articles/install-guide/pyinstall.md
@@ -21,13 +21,13 @@ Install the QDK to develop Python host programs to call Q# operations.
 
 1. Install the `qsharp` package, a Python package that enables interop between Q# and Python.
 
-    ```bash
+    ```
     pip install qsharp
     ```
 
 1. Install IQ#, a kernel used by Jupyter and Python that provides the core functionality for compiling and executing Q# operations.
 
-    ```bash
+    ```dotnetcli
     dotnet tool install -g Microsoft.Quantum.IQSharp
     dotnet iqsharp install
     ```
@@ -64,15 +64,15 @@ Install the QDK to develop Python host programs to call Q# operations.
 
     - Run the program:
 
-        ```bash
+        ```
         python hello_world.py
         ```
 
     - Verify the output. Your program should output the following lines:
 
-        ```bash
+        ```
         Hello from quantum world!
-       ```
+        ```
 
 
 > [!NOTE]

--- a/articles/install-guide/qjupyter.md
+++ b/articles/install-guide/qjupyter.md
@@ -27,7 +27,7 @@ IQ# (pronounced i-q-sharp) is an extension primarily used by Jupyter and Python 
 
 1. Install the `iqsharp` package
 
-    ```bash
+    ```dotnetcli
     dotnet tool install -g Microsoft.Quantum.IQSharp
     dotnet iqsharp install
     ```
@@ -36,7 +36,7 @@ IQ# (pronounced i-q-sharp) is an extension primarily used by Jupyter and Python 
 
     - Run the following command to start the notebook server:
 
-        ```bash
+        ```
         jupyter notebook
         ```
 

--- a/articles/install-guide/update.md
+++ b/articles/install-guide/update.md
@@ -171,7 +171,7 @@ Select your development environment below.
 
     You should see the following output:
 
-    ```bash
+    ```
     iqsharp: 0.10.1912.501
     Jupyter Core: 1.2.20112.0
     ```
@@ -180,19 +180,19 @@ Select your development environment below.
 
 3. Update the `qsharp` package
 
-    ```bash
+    ```
     pip install qsharp --upgrade
     ```
 
 4. Verify the `qsharp` version
 
-    ```bash
+    ```
     pip show qsharp
     ```
 
     You should see the following output:
 
-    ```bash
+    ```
     Name: qsharp
     Version: 0.10.1912.501
     Summary: Python client for Q#, a domain-specific quantum programming language
@@ -201,7 +201,7 @@ Select your development environment below.
 
 5. Run the following command from the location of your `.qs` files
 
-    ```bash
+    ```
     python -c "import qsharp; qsharp.reload()"
     ```
 
@@ -224,7 +224,7 @@ Select your development environment below.
 
     Your output should be similar to the following:
 
-    ```bash
+    ```
     iqsharp: 0.10.1912.501
     Jupyter Core: 1.2.20112.0
     ```

--- a/articles/quickstart.md
+++ b/articles/quickstart.md
@@ -58,7 +58,7 @@ This tutorial uses a host programs and consists of two parts:
 
 1. Create a new Q# project:
 
-    ```bash
+    ```dotnetcli
     dotnet new console -lang Q# --output Bell
     cd Bell
     ```
@@ -282,7 +282,7 @@ Init:1    0s=0    1s=1000
 
 1. Run the following at your terminal:
 
-    ```bash
+    ```dotnetcli
     dotnet run
     ```
 

--- a/articles/quickstart.md
+++ b/articles/quickstart.md
@@ -58,7 +58,7 @@ This tutorial uses a host programs and consists of two parts:
 
 1. Create a new Q# project:
 
-    ```dotnetcli
+    ```
     dotnet new console -lang Q# --output Bell
     cd Bell
     ```
@@ -67,7 +67,7 @@ This tutorial uses a host programs and consists of two parts:
 
 1. Rename the Q# file
 
-    ```bash
+    ```
     mv Operation.qs Bell.qs
     ```
 


### PR DESCRIPTION
We got user feedback (https://github.com/microsoft/iqsharp/issues/153) that the `bash` label in a few places was confusing, because the text being displayed was not actually Bash-specific. This PR just removes it from several places, updating it to `dotnetcli` where applicable.