### PR TITLE
Depth/width statistics on the resource tracer represent lower bounds

### DIFF
--- a/articles/user-guide/machines/qc-trace-simulator/depth-counter.md
+++ b/articles/user-guide/machines/qc-trace-simulator/depth-counter.md
@@ -9,11 +9,8 @@ uid: microsoft.quantum.machines.qc-trace-simulator.depth-counter
 ---
 # Depth Counter
 
-The `Depth Counter` is a part of the quantum computer [Trace
-Simulator](xref:microsoft.quantum.machines.qc-trace-simulator.intro).
-It is used to gather counts of the depth of
-every operation invoked in a quantum program. All operations from
-<xref:microsoft.quantum.intrinsic> are expressed in terms of single qubit rotations,
+The `Depth Counter` is a part of the quantum computer [Trace Simulator](xref:microsoft.quantum.machines.qc-trace-simulator.intro).
+It is used to gather counts that represent the lower bound of the depth of every operation invoked in a quantum program. All operations from <xref:microsoft.quantum.intrinsic> are expressed in terms of single qubit rotations,
 T gates, single qubit Clifford gates, CNOT gates and measurements of multi-qubit
 Pauli observables. Users can set the depth for each of the primitive operations via the `gateTimes` field of <xref:Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.QCTraceSimulatorConfiguration>.
 

--- a/articles/user-guide/machines/resources-estimator.md
+++ b/articles/user-guide/machines/resources-estimator.md
@@ -105,8 +105,8 @@ The following is the list of metrics estimated by the `ResourcesEstimator`:
 * __Measure__:  The count of any measurements executed.
 * __R__: The count of any single qubit rotations executed, excluding T, Clifford and Pauli gates.
 * __T__: The count of T gates and their conjugates, including the T gate, T_x = H.T.H, and T_y = Hy.T.Hy, executed.
-* __Depth__: Depth of the quantum circuit executed by the Q# operation. By default, only T gates are counted in the depth, see [depth counter](xref:microsoft.quantum.machines.qc-trace-simulator.depth-counter) for details.
-* __Width__: Maximum number of qubits allocated during the execution of the Q# operation.
+* __Depth__: The lower bound for the depth of the quantum circuit executed by the Q# operation. By default, only T gates are counted in the depth, see [depth counter](xref:microsoft.quantum.machines.qc-trace-simulator.depth-counter) for details.
+* __Width__: The lower bound for the maximum number of qubits allocated during the execution of the Q# operation. It might not be possible to achieve both __Depth__ and __Width__ lower bounds simultaneously.
 * __BorrowedWidth__: Maximum number of qubits borrowed inside the Q# operation.
 
 


### PR DESCRIPTION
Addresses https://github.com/microsoft/qsharp-runtime/issues/192 by clarifying the documentation.