### PR TITLE
remove locale from code sample URL in tutorial TOC.yml

### DIFF
--- a/articles/tutorials/toc.yml
+++ b/articles/tutorials/toc.yml
@@ -9,4 +9,4 @@
   - name: Learn Q# with the Quantum Katas
     href: intro-to-katas.md
   - name: Q# code samples
-    href: https://docs.microsoft.com/en-us/samples/browse/?languages=qsharp
+    href: https://docs.microsoft.com/samples/browse/?languages=qsharp


### PR DESCRIPTION
The link to the code sample page in the toc.yml contains the locale, which is causing the rendered URL to use the locale twice, resulting in a 404:

https://docs.microsoft.com/en-us/en-us/samples/browse/languages=qsharp

The link URL has been like this forever, so I'm not sure why it's just showing this behavior now. Content guidelines state that any link to another Microsoft property should not contain the locale, so it needs to be brought up to standard anyway. 