### PR TITLE
Fix condition in Fact example for positive number

### DIFF
--- a/articles/user-guide/using-qsharp/testing-debugging.md
+++ b/articles/user-guide/using-qsharp/testing-debugging.md
@@ -157,7 +157,7 @@ Thus, if we proceed past a call to `PositivityFact`, we can be assured by that i
 Note that we can implement the same behavior as `PositivityFact` using the [`Fact`](xref:microsoft.quantum.diagnostics.fact) function from the <xref:microsoft.quantum.diagnostics> namespace:
 
 ```qsharp
-	Fact(value <= 0, "Expected a positive number.");
+	Fact(value > 0, "Expected a positive number.");
 ```
 
 *Assertions*, on the other hand, are used similarly to facts, but may be dependent on the state of the target machine. 


### PR DESCRIPTION
Repeat of #786 which was overwritten by https://github.com/MicrosoftDocs/quantum-docs-pr/commit/1e0a90a19714a92a582312e3fd014233ab5e54fe#diff-27fc2854656d812ac1e0200faed034c7L160: The first argument to Fact is condition that should hold, not condition that causes the code to fail, so the comparison should be opposite to the previous example.