### PR TITLE
Review of Brad's user guide copyedit

### DIFF
--- a/articles/user-guide/using-qsharp/operations-functions.md
+++ b/articles/user-guide/using-qsharp/operations-functions.md
@@ -24,7 +24,7 @@ Operation names must be unique within a namespace and can not conflict with type
 An operation declaration consists of the keyword `operation`, followed by the symbol that is the operation's name, a typed identifier tuple that defines the arguments to the operation, a colon `:`, a type annotation that describes the operation's result type, optionally an annotation with the operation characteristics, an open brace, and then the body of the operation declaration, enclosed in braces `{ }`.
 
 Each operation takes an input, produces an output, and specifies the implementation for one or more operation specializations.
-The possible specializations, and how to define and call them, are detailed the different sections of this article.
+The possible specializations, and how to define and call them, are detailed in the different sections of this article.
 For now, consider the following operation, which defines only a default body specialization and takes a single qubit as its input, then calls the built-in <xref:microsoft.quantum.intrinsic.x> operation on that input:
 
 ```qsharp
@@ -94,22 +94,22 @@ Functors do not have a representation in the Q# type system.
 It is thus currently not possible to bind them to a variable or pass them as arguments. 
 
 Use a functor by applying it to an operation, which returns a new operation.
-For example, applying the `Adjoint functor` to the `Y` operation returns the new operation `Adjoint Y`. You can invoke the new operation like any other operation.
+For example, applying the `Adjoint` functor to the `Y` operation returns the new operation `Adjoint Y`. You can invoke the new operation like any other operation.
 For an operation to support the application of the `Adjoint` or `Controlled` functors, its return type necessarily needs to be `Unit`. 
 
 #### `Adjoint` functor
 
-Thus, `Adjoint Y(q1)` applies the Adjoint functor to the `Y` operation to generate a new operation, and applies that new operation to `q1`.
+Thus, `Adjoint Y(q1)` applies the `Adjoint` functor to the `Y` operation to generate a new operation, and applies that new operation to `q1`.
 The new operation has the same signature and type as the base operation `Y`.
 In particular, the new operation also supports `Adjoint`, and supports `Controlled` if and only if the base operation did.
-The Adjoint functor is its own inverse; that is, `Adjoint Adjoint Op` is always the same as `Op`.
+The `Adjoint` functor is its own inverse; that is, `Adjoint Adjoint Op` is always the same as `Op`.
 
 #### `Controlled` functor
 
-Similarly, `Controlled X(controls, target)` applies the Controlled functor to the `X` operation to generate a new operation, and applies that new operation to `controls` and `target`.
+Similarly, `Controlled X(controls, target)` applies the `Controlled` functor to the `X` operation to generate a new operation, and applies that new operation to `controls` and `target`.
 
 > [!NOTE]
-> In Q#, controlled versions always take an array of control qubits, and the specified state is for all of the control qubits to always be in the computational (`PauliZ`) `One` state, $\ket{1}$.
+> In Q#, controlled versions always take an array of control qubits, and the controlling is always based on all of the control qubits being in the computational (`PauliZ`) `One` state, $\ket{1}$.
 > Controlling based on other states is achieved by applying the appropriate unitary operation to the control qubits before the controlled operation, and then applying the inverses of the unitary operation after the controlled operation.
 > For example, applying an `X` operation to a control qubit before and after a controlled operation causes the operation to control on the `Zero` state ($\ket{0}$) for that qubit; applying an `H` operation before and after controls on the `PauliX` `One` state, that is -1 eigenvalue of Pauli X, $\ket{-} \mathrel{:=} (\ket{0} - \ket{1}) / \sqrt{2}$ rather than the `PauliZ` `One` state.
 
@@ -391,7 +391,7 @@ operation ApplyWith<'T>(
 }
 ```
 
-Starting with our 0.9 release, Q# supportS a conjugation statement that implements the preceding transformation. Using that statement, the operation `ApplyWith` can be implemented in the following way:
+Starting with our 0.9 release, Q# supports a conjugation statement that implements the preceding transformation. Using that statement, the operation `ApplyWith` can be implemented in the following way:
 
 ```qsharp
 operation ApplyWith<'T>(

--- a/articles/user-guide/using-qsharp/testing-debugging.md
+++ b/articles/user-guide/using-qsharp/testing-debugging.md
@@ -24,13 +24,13 @@ Q# supports creating unit tests for quantum programs, and which can run as tests
 
 #### [Visual Studio 2019](#tab/tabid-vs2019)
 
-Open Visual Studio 2019. Go to the `File` menu and select `New` > `Project...`.
-In the upper right corner, search for `Q#`, and select the `Q# Test Project` template.
+Open Visual Studio 2019. Go to the **File** menu and select **New > Project...**.
+In the upper right corner, search for `Q#`, and select the **Q# Test Project** template.
 
 #### [Command Line / Visual Studio Code](#tab/tabid-vscode)
 
 From your favorite command line, run the following command:
-```bash
+```dotnetcli
 $ dotnet new xunit -lang Q# -o Tests
 $ cd Tests
 $ code . # To open in Visual Studio Code
@@ -53,17 +53,17 @@ Initially, this file contains one sample unit test `AllocateQubit` which checks 
     }
 ```
 
-:new: Any Q# operation or function that takes an argument of type `Unit` and returns `Unit` can be marked as a unit test via the `@Test("...")` attribute. 
-In the previous example, the argument to that attribute, `QuantumSimulator`, specifies the target on which the test runs. A single test can run on multiple targets. For example, add an attribute `@Test("ResourcesEstimator")` before `AllocateQubit`. 
+Any Q# operation or function that takes an argument of type `Unit` and returns `Unit` can be marked as a unit test via the `@Test("...")` attribute. 
+In the previous example, the argument to that attribute, `"QuantumSimulator"`, specifies the target on which the test runs. A single test can run on multiple targets. For example, add an attribute `@Test("ResourcesEstimator")` before `AllocateQubit`. 
 ```qsharp
     @Test("QuantumSimulator")
     @Test("ResourcesEstimator")
     operation AllocateQubit () : Unit {
         ...
 ```
-Save the file and run all tests. There should now be two unit tests, one where AllocateQubit runs on the QuantumSimulator, and one where it runs in the ResourceEstimator. 
+Save the file and run all tests. There should now be two unit tests, one where `AllocateQubit` runs on the `QuantumSimulator`, and one where it runs in the `ResourcesEstimator`. 
 
-The Q# compiler recognizes the built-in targets *QuantumSimulator*, *ToffoliSimulator*, and *ResourcesEstimator* as valid execution targets for unit tests. It is also possible to specify any fully qualified name to define a custom execution target. 
+The Q# compiler recognizes the built-in targets `"QuantumSimulator"`, `"ToffoliSimulator"`, and `"ResourcesEstimator"` as valid execution targets for unit tests. It is also possible to specify any fully qualified name to define a custom execution target. 
 
 ### Running Q# Unit Tests
 
@@ -151,7 +151,7 @@ function PositivityFact(value : Double) : Unit
 ```
 
 Here, the keyword `fail` indicates that the computation should not proceed, and raises an exception in the target machine running the Q# program.
-By definition, a failure of this kind cannot be observed from within Q#, as the target machine no longer runs the Q# code after running a `fail` statement.
+By definition, a failure of this kind cannot be observed from within Q#, as the target machine no longer runs the Q# code after reaching a `fail` statement.
 Thus, if we proceed past a call to `PositivityFact`, we can be assured that its input was positive.
 
 Note that we can implement the same behavior as `PositivityFact` using the [`Fact`](xref:microsoft.quantum.diagnostics.fact) function from the <xref:microsoft.quantum.diagnostics> namespace:
@@ -160,7 +160,7 @@ Note that we can implement the same behavior as `PositivityFact` using the [`Fac
 	Fact(value > 0, "Expected a positive number.");
 ```
 
-*Assertions*, on the other hand, are used similarly to facts but may  depend on the state of the target machine. 
+*Assertions*, on the other hand, are used similarly to facts but may depend on the state of the target machine. 
 Correspondingly, they are defined as operations, whereas facts are defined as functions (as in the previous example).
 To understand the distinction, consider the following use of a fact within an assertion:
 

--- a/articles/user-guide/using-qsharp/variables.md
+++ b/articles/user-guide/using-qsharp/variables.md
@@ -17,7 +17,7 @@ The left-hand-side of a binding consists of a symbol tuple and the right-hand si
 
 ## Immutable Variables
 
-You can assign a value of any type in Q# to a variable for reuse withing an operation or function by using the `let` keyword. 
+You can assign a value of any type in Q# to a variable for reuse within an operation or function by using the `let` keyword. 
 
 An immutable binding consists of the keyword `let`, followed by a symbol or symbol tuple, an equals sign `=`, an expression to bind the symbol(s) to, and a terminating semicolon.
 
@@ -33,18 +33,18 @@ This assigns a particular array of Pauli operators to the variable name (or "sym
 > In the previous example, there is no need to explicitly specify the type of the new variable, as the expression on the right-hand side of the `let` statement is unambiguous, and the compiler infers the correct type. 
 
 Variables defined using `let` are *immutable*, meaning that once you define it, you can no longer change it in any way.
-This provides several beneficial optimizations, including optimization of the classical logic that acts on variables to be reordered for applying the `Adjoint` variant of an operation.
+This allows for several beneficial optimizations, including optimization of the classical logic that acts on variables to be reordered for applying the `Adjoint` variant of an operation.
 
 ## Mutable Variables
 
 As an alternative to creating a variable with `let`, the `mutable` keyword creates a mutable variable that *can* be rebound after it is initially created by using the `set` keyword.
 
-You can rebound symbols declared and bound as part of a `mutable` statement to a different value later in the code. 
+You can rebind symbols declared and bound as part of a `mutable` statement to a different value later in the code. 
 If a symbol is rebound later in the code, its type does not change, and the newly bound value must be compatible with that type.
 
 ### Rebinding of Mutable Symbols
 
-You can rebound a mutable variable using a `set` statement.
+You can rebind a mutable variable using a `set` statement.
 Such a rebinding consists of the keyword `set`, followed by a symbol or symbol tuple, an equals sign `=`, an expression to rebind the symbol(s) to, and a terminating semicolon.
 
 The following are some examples of rebinding statement techniques.
@@ -72,7 +72,7 @@ for (i in 1 .. 2 .. 10) {
 ```
 
 Similar statements are available for all binary operators in which the type of the left-hand side matches the expression type. 
-These statements provide, for example, a convenient way to accumulate values.
+These statements provide a convenient way to accumulate values.
 
 For example, supposing `qubits` is a register of qubits:
 ```qsharp
@@ -130,7 +130,7 @@ operation SampleUniformDistrbution(nSamples : Int, nSteps : Int) : Double[] {
 
 ```
 
-Using the library tools for arrays provided in [`Microsoft.Quantum.Arrays`](xref:microsoft.quantum.arrays), you can, for example, easily define a function that returns an array of Paulis where the Pauli at index `i` takes the given value, and all other entries are the identity.
+Using the library tools for arrays provided in [`Microsoft.Quantum.Arrays`](xref:microsoft.quantum.arrays), you can, for example, easily define a function that returns an array of `Pauli` types where the element at index `i` takes a given `Pauli` value, and all other entries are the identity (`PauliI`).
 
 Here are two definitions of such a function, with the second taking advantage of the tools at our disposal.
 
@@ -139,13 +139,13 @@ function PauliEmbedding(pauli : Pauli, length : Int, location : Int) : Pauli[] {
     mutable pauliArray = new Pauli[length];             // initialize pauliArray of given length
     for (index in 0 .. length - 1) {                    // iterate over the integers in the length range
         set pauliArray w/= index <-                     // change the value at index to input pauli or PauliI
-            index == location ? pauli | PauliI;         // cond. expression evaluating to pauli or PauliI dep. on whether index==location
+            index == location ? pauli | PauliI;         // cond. expression evaluating to pauli if index==location and PauliI if not
     }    
     return pauliArray;
 }
 ```
 
-Instead of iterating over each index in the array, and conditionally setting it to `PauliI` or `Pauli`, you can instead use `ConstantArray` from [`Microsoft.Quantum.Arrays`](xref:microsoft.quantum.arrays) to create an array of `PauliI` types, and then simply return a copy-and-update expression in which you've changed the specific value at index `location`:
+Instead of iterating over each index in the array, and conditionally setting it to `PauliI` or the given `pauli`, you can instead use `ConstantArray` from [`Microsoft.Quantum.Arrays`](xref:microsoft.quantum.arrays) to create an array of `PauliI` types, and then simply return a copy-and-update expression in which you've changed the specific value at index `location`:
 
 ```qsharp
 function PauliEmbedding(pauli : Pauli, length : Int, location : Int) : Pauli[] {


### PR DESCRIPTION
Brad's PR #910 had slipped into master by mistake, so just gave it a close look over.

A few typos and small content changes. One problem area where `M` and `Measure` were being used interchangeably (probably a holdover from long ago that had gone under the radar)