### PR TITLE
Fix action button in the style guide

### DIFF
--- a/articles/resources/contributing/style-guide.md
+++ b/articles/resources/contributing/style-guide.md
@@ -381,9 +381,8 @@ The compiler provided with the Quantum Development Kit extracts these comments a
 Similarly, the language server provided with the Quantum Development Kit uses these comments to provide help to users when they hover over symbols in their Q# code.
 Making use of documentation comments can thus help users to make sense of code by providing a useful reference for details that are not easily expressed using the other conventions in this document.
 
-<div class="nextstepaction">
-    [Documentation comment syntax reference](xref:microsoft.quantum.guide.filestructure#documentation-comments)
-</div>
+> [!div class="nextstepaction"]
+> [Documentation comment syntax reference](xref:microsoft.quantum.guide.filestructure#documentation-comments).
 
 In order to effectively use this functionality to help users, we recommend keeping a few things in mind as you write documentation comments.
 


### PR DESCRIPTION
Markdown-style link doesn't seem to work inside <div> tag, switching to the div style used in other places fixes it.