### PR TITLE
Update references to deprecated Assert functions

### DIFF
--- a/articles/user-guide/libraries/standard/diagnostics.md
+++ b/articles/user-guide/libraries/standard/diagnostics.md
@@ -56,18 +56,18 @@ The Q# standard libraries provide several different functions for representing f
 
 In practice, assertions rely on the fact that classical simulations of quantum mechanics need not obey the [no-cloning theorem](https://arxiv.org/abs/quant-ph/9607018), such that we can make unphysical measurements and assertions when using a simulator for our target machine.
 Thus, we can test individual operations on a classical simulator before deploying on hardware.
-On target machines which do not allow evaluation of assertions, calls to <xref:microsoft.quantum.intrinsic.assert> can be safely ignored.
+On target machines which do not allow evaluation of assertions, calls to <xref:microsoft.quantum.diagnostics.assertmeasurement> can be safely ignored.
 
-More generally, the <xref:microsoft.quantum.intrinsic.assert> operation asserts that measuring the given qubits in the
+More generally, the <xref:microsoft.quantum.diagnostics.assertmeasurement> operation asserts that measuring the given qubits in the
 given Pauli basis will always have the given result.
 If the assertion fails, the execution ends by calling `fail` with the
 given message.
 By default, this operation is not implemented; simulators that can support it
 should provide an implementation that performs runtime checking.
-`Assert` has signature `((Pauli[], Qubit[], Result, String) -> ())`.
-Since `Assert` is a function with an empty tuple as its output type, no effects from having called `Assert` are observable within a Q# program.
+`AssertMeasurement` has signature `((Pauli[], Qubit[], Result, String) -> ())`.
+Since `AssertMeasurement` is a function with an empty tuple as its output type, no effects from having called `AssertMeasurement` are observable within a Q# program.
 
-The <xref:microsoft.quantum.intrinsic.assertprob> operation function asserts that measuring the given qubits in the
+The <xref:microsoft.quantum.diagnostics.assertmeasurementprobability> operation function asserts that measuring the given qubits in the
 given Pauli basis will have the given result with the given probability,
 within some tolerance.
 Tolerance is additive (e.g. `abs(expected-actual) < tol`).
@@ -75,7 +75,7 @@ If the assertion fails, the execution ends by calling `fail`
 with the given message.
 By default, this operation is not implemented; simulators that can support it
 should provide an implementation that performs runtime checking.
-`AssertProb` has signature `((Pauli[], Qubit[], Result, Double, String, Double) -> Unit)`. The first of `Double` parameters gives the desired probability of the result, and the second one the tolerance.
+`AssertMeasurementProbability` has signature `((Pauli[], Qubit[], Result, Double, String, Double) -> Unit)`. The first of `Double` parameters gives the desired probability of the result, and the second one the tolerance.
 
 We can do more than assert a single measurement, using that the classical information used by a simulator to represent the internal state of a qubit is amenable to copying, such that we do not need to actually perform a measurement to test our assertion.
 In particular, this allows us to reason about *incompatible* measurements that would be impossible on actual hardware.
@@ -105,7 +105,7 @@ using (register = Qubit()) {
 ```
 
 More generally, however, we may not have access to assertions about states that do not coincide with eigenstates of Pauli operators.
-For example, $\ket{\psi} = (\ket{0} + e^{i \pi / 8} \ket{1}) / \sqrt{2}$ is not an eigenstate of any Pauli operator, such that we cannot use <xref:microsoft.quantum.intrinsic.assertprob> to uniquely determine that a state $\ket{\psi'}$ is equal to $\ket{\psi}$.
+For example, $\ket{\psi} = (\ket{0} + e^{i \pi / 8} \ket{1}) / \sqrt{2}$ is not an eigenstate of any Pauli operator, such that we cannot use <xref:microsoft.quantum.diagnostics.assertmeasurementprobability> to uniquely determine that a state $\ket{\psi'}$ is equal to $\ket{\psi}$.
 Instead, we must decompose the assertion $\ket{\psi'} = \ket{\psi}$ into assumptions that can be directly tested using  the primitives supported by our simulator.
 To do so, let $\ket{\psi} = \alpha \ket{0} + \beta \ket{1}$ for complex numbers $\alpha = a\_r + a\_i i$ and $\beta$.
 Note that this expression requires four real numbers $\{a\_r, a\_i, b\_r, b\_i\}$ to specify, as each complex number can be expressed as the sum of a real and imaginary part.

--- a/articles/user-guide/using-qsharp/control-flow.md
+++ b/articles/user-guide/using-qsharp/control-flow.md
@@ -281,9 +281,9 @@ Finally, here is an example of an RUS pattern to prepare a quantum state $\frac{
 Notable programmatic features shown in this operation are:
 
 * A more complex `fixup` part of the loop, which involves quantum operations. 
-* The use of `AssertProb` statements to ascertain the probability of measuring the quantum state at certain specified points in the program.
+* The use of `AssertMeasurementProbability` statements to ascertain the probability of measuring the quantum state at certain specified points in the program.
 
-For more information about the [`Assert`](xref:microsoft.quantum.intrinsic.assert) and [`AssertProb`](xref:microsoft.quantum.intrinsic.assertprob) operations, see [Testing and debugging](xref:microsoft.quantum.guide.testingdebugging).
+For more information about the [`AssertMeasurement`](xref:microsoft.quantum.diagnostics.assertmeasurement) and [`AssertMeasurementProbability`](xref:microsoft.quantum.diagnostics.assertmeasurementprobability) operations, see [Testing and debugging](xref:microsoft.quantum.guide.testingdebugging).
 
 ```qsharp
 operation PrepareStateUsingRUS(target : Qubit) : Unit {
@@ -292,10 +292,10 @@ operation PrepareStateUsingRUS(target : Qubit) : Unit {
         repeat {
             // We expect the target and auxiliary qubits to each be in
             // the |+> state.
-            AssertProb(
+            AssertMeasurementProbability(
                 [PauliX], [target], Zero, 1.0,
                 "target qubit should be in the |+> state", 1e-10 );
-            AssertProb(
+            AssertMeasurementProbability(
                 [PauliX], [auxiliary], Zero, 1.0,
                 "auxiliary qubit should be in the |+> state", 1e-10 );
 
@@ -305,7 +305,7 @@ operation PrepareStateUsingRUS(target : Qubit) : Unit {
 
             // The probability of measuring |+> state on the auxiliary qubit
             // is 3/4.
-            AssertProb(
+            AssertMeasurementProbability(
                 [PauliX], [auxiliary], Zero, 3. / 4.,
                 "Error: the probability to measure |+> in the first
                 auxiliary must be 3/4",

--- a/articles/user-guide/using-qsharp/testing-debugging.md
+++ b/articles/user-guide/using-qsharp/testing-debugging.md
@@ -46,7 +46,7 @@ Initially, this file contains one sample unit test `AllocateQubit` which checks 
     operation AllocateQubit () : Unit {
 
         using (qubit = Qubit()) {
-            Assert([PauliZ], [qubit], Zero, "Newly allocated qubit must be in the |0⟩ state.");
+            AssertMeasurement([PauliZ], [qubit], Zero, "Newly allocated qubit must be in the |0⟩ state.");
         }
         
         Message("Test passed");
@@ -175,7 +175,7 @@ Here, we are using the operation <xref:microsoft.quantum.environment.getqubitsav
 As this depends on the global state of the program and its execution environment, our definition of `AssertQubitsAreAvailable` must be an operation as well.
 However, we can use that global state to yield a simple `Bool` value as input to the `Fact` function.
 
-[The prelude](xref:microsoft.quantum.libraries.standard.prelude), building on these ideas, offers two especially useful assertions, <xref:microsoft.quantum.intrinsic.assert> and <xref:microsoft.quantum.intrinsic.assertprob> both modeled as operations onto `()`. These assertions each take a Pauli operator describing a particular measurement of interest, a quantum register on which a measurement is performed, and a hypothetical outcome.
+[The prelude](xref:microsoft.quantum.libraries.standard.prelude), building on these ideas, offers two especially useful assertions, <xref:microsoft.quantum.diagnostics.assertmeasurement> and <xref:microsoft.quantum.diagnostics.assertmeasurementprobability> both modeled as operations onto `()`. These assertions each take a Pauli operator describing a particular measurement of interest, a quantum register on which a measurement is performed, and a hypothetical outcome.
 Target machines which work by simulation are not bound by [the no-cloning theorem](https://en.wikipedia.org/wiki/No-cloning_theorem), and can perform such measurements without disturbing the register that passes to such assertions.
 A simulator can then, similar to the `PositivityFact` function previous, stop computation if the hypothetical outcome is not observed in practice:
 
@@ -183,14 +183,14 @@ A simulator can then, similar to the `PositivityFact` function previous, stop co
 using (register = Qubit()) 
 {
     H(register);
-    Assert([PauliX], [register], Zero);
+    AssertMeasurement([PauliX], [register], Zero);
     // Even though we do not have access to states in Q#,
     // we know by the anthropic principle that the state
     // of register at this point is |+〉.
 }
 ```
 
-On physical quantum hardware, where the no-cloning theorem prevents examination of a quantum state, the `Assert` and `AssertProb` operations simply return `()` with no other effect.
+On physical quantum hardware, where the no-cloning theorem prevents examination of a quantum state, the `AssertMeasurement` and `AssertMeasurementProbability` operations simply return `()` with no other effect.
 
 The <xref:microsoft.quantum.diagnostics> namespace provides several more functions of the `Assert` family, with which you can check more advanced conditions. 
 


### PR DESCRIPTION
`Assert` --> `AssertMeasurement`
`AssertProb` --> `AssertMeasurementProbability`