### PR TITLE
Clarify 64-bit conda install requirement

### DIFF
--- a/articles/quickstarts/install-jupyter.md
+++ b/articles/quickstarts/install-jupyter.md
@@ -23,7 +23,7 @@ IQ# (pronounced i-q-sharp) is an extension primarily used by Jupyter and Python 
 
 ### [Install using conda (recommended)](#tab/tabid-conda)
 
-1. Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual#Downloads).
+1. Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual#Downloads). **Note:** 64-bit installation required.
 
 1. Open an Anaconda Prompt.
 

--- a/articles/quickstarts/install-python.md
+++ b/articles/quickstarts/install-python.md
@@ -16,7 +16,7 @@ Install the QDK to develop Python host programs to call Q# operations.
 
 ### [Install using conda (recommended)](#tab/tabid-conda)
 
-1. Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual#Downloads).
+1. Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual#Downloads). **Note:** 64-bit installation required.
 
 1. Open an Anaconda Prompt.
 


### PR DESCRIPTION
Since the QDK is only built for 64-bit processors, the conda installation must also be 64-bit in order to pull the 64-bit conda `iqsharp` and `qsharp` packages.