### PR TITLE
Updating documentation steps regarding the VS Code templates

### DIFF
--- a/articles/quickstarts/install-command-line.md
+++ b/articles/quickstarts/install-command-line.md
@@ -49,14 +49,6 @@ Follow the instructions at the tab corresponding to your environment.
 
 ### [VS Code](#tab/tabid-vscode)
 
-Install the Q# project templates:
-
-1. Open VS Code.
-2. Click **View** -> **Command Palette**.
-3. Select **Q#: Install project templates**.
-
-When **Project templates installed successfully** displays, the QDK is ready to use with your own applications and libraries.
-
 To create a new project:
 
 1. Click **View** -> **Command Palette** and select **Q#: Create New Project**.
@@ -98,24 +90,30 @@ To run the application:
 
 Verify your installation by creating a Q# `Hello World` application.
 
+1. Install the project templates.
+
+    ```dotnetcli
+    dotnet new -i Microsoft.Quantum.ProjectTemplates
+    ```
+
 1. Create a new application:
     ```dotnetcli
     dotnet new console -lang Q# -o runSayHello
     ```
 
-2. Navigate to the application directory:
+1. Navigate to the application directory:
     ```dotnetcli
     cd runSayHello
     ```
 
     This directory should now contain a file `Program.qs`, which is a Q# program that defines a simple operation to print a message to the console. You can modfiy this template with a text editor and overwrite it with your own quantum applications. 
 
-3. Run the program:
+1. Run the program:
     ```dotnetcli
     dotnet run
     ```
 
-4. You should see the following text printed: `Hello quantum world!`
+1. You should see the following text printed: `Hello quantum world!`
 
 ***
 

--- a/articles/quickstarts/update.md
+++ b/articles/quickstarts/update.md
@@ -308,7 +308,7 @@ You can now use the updated IQ# kernel to run your existing Q# Jupyter Notebooks
     dotnet new -i Microsoft.Quantum.ProjectTemplates
     ```
 
-   Alternatively, if intend to use the command line templates, and you already have the VS Code QDK extension installed, you can update the project templates from the extension itself:
+   Alternatively, if you intend to use the command line templates, and already have the VS Code QDK extension installed, you can update the project templates from the extension itself:
 
    - [Update the QDK extension](#update-vs-code-qdk-extension)
    - In VS Code, go to **View** -> **Command Palette**

--- a/articles/quickstarts/update.md
+++ b/articles/quickstarts/update.md
@@ -298,16 +298,19 @@ You can now use the updated IQ# kernel to run your existing Q# Jupyter Notebooks
     - Select the **Microsoft Quantum Development Kit for Visual Studio Code** extension
     - Reload the extension
 
-2. Update the Quantum project templates:
-
-   - Go to **View** -> **Command Palette**
-   - Select **Q#: Install project templates**
-   - After a few seconds you should get a popup confirming "project templates installed successfully"
-
 ### C#, using the `dotnet` command-line tool
 
 1. Update the Quantum project templates for .NET
 
+    From the command line:
+
     ```dotnetcli
     dotnet new -i Microsoft.Quantum.ProjectTemplates
     ```
+
+   Alternatively, if intend to use the command line templates, and you already have the VS Code QDK extension installed, you can update the project templates from the extension itself:
+
+   - [Update the QDK extension](#update-vs-code-qdk-extension)
+   - In VS Code, go to **View** -> **Command Palette**
+   - Select **Q#: Install command line project templates**
+   - After a few seconds you should get a popup confirming "project templates installed successfully"


### PR DESCRIPTION
The VS Code QDK extension no longer depends on the command line extensions to create new projects, however it still provides a command to install them for those developers who prefer to build from the command line.

This change updates the documentation accordingly.
