### PR TITLE
Minor fix on full state sim page

### DIFF
--- a/articles/user-guide/machines/full-state-simulator.md
+++ b/articles/user-guide/machines/full-state-simulator.md
@@ -45,14 +45,13 @@ When running a Q# program from the command line, the full state simulator is the
 ```dotnetcli
 dotnet run
 dotnet run -s QuantumSimulator
-
 ```
 
 ### Invoking the simulator from Juptyer Notebooks
 
 Use the IQ# magic command [%simulate](xref:microsoft.quantum.iqsharp.magic-ref.simulate) to run the Q# operation.
 
-```dotnetcli
+```
 %simulate myOperation
 ```
 ## Seeding the simulator


### PR DESCRIPTION
@bradben I realized I forgot to mention that the same small things from the resources estimator and toffoli sim page were here too. Just the extra line in one code block, and the Jupyter code being labeled `dotnetcli`.