### PR TITLE
Updating version samples to match current format.

### DIFF
--- a/articles/quickstarts/update.md
+++ b/articles/quickstarts/update.md
@@ -49,7 +49,7 @@ Regardless of whether you are using C# or Python to host Q# operations, follow t
 5. In each of the .csproj files, set the SDK to `Microsoft.Quantum.Sdk`, as indicated in the line below. Please notice that the version number should be the latest available, and you can determine it by reviewing the [release notes](https://docs.microsoft.com/quantum/relnotes/).
 
     ```xml
-    <Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.207">
+    <Project Sdk="Microsoft.Quantum.Sdk/0.12.20072018">
     ```
 
 6. Save and close all files in your solution.
@@ -89,7 +89,7 @@ You can now skip ahead to [update your Visual Studio QDK extension](#update-visu
     dotnet clean [project_name].csproj
     ```
 
-3. Determine the current version of the QDK. To find it, you can review the [release notes](https://docs.microsoft.com/quantum/relnotes/). The version will be in a format similar to `0.11.2006.207`.
+3. Determine the current version of the QDK. To find it, you can review the [release notes](https://docs.microsoft.com/quantum/relnotes/). The version will be in a format similar to `0.12.20072018`.
 
 4. In each of your `.csproj` files, go through the following steps:
 
@@ -104,7 +104,7 @@ You can now skip ahead to [update your Visual Studio QDK extension](#update-visu
     - Replace the reference to the SDK in the project definition. Make sure that the version number corresponds to the value determined in **step 3**.
 
         ```xml
-        <Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.207">
+        <Project Sdk="Microsoft.Quantum.Sdk/0.12.20072018">
         ```
 
     - Remove the reference to package `Microsoft.Quantum.Development.Kit` if present, which will be specified in the following entry:
@@ -123,7 +123,7 @@ You can now skip ahead to [update your Visual Studio QDK extension](#update-visu
         References to packages have the following format:
 
         ```xml
-        <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2006.207" />
+        <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20072018" />
         ```
 
     - Save the updated file.
@@ -190,7 +190,7 @@ The update procedure depends on whether you originally installed using conda or 
     You should see the following output:
 
     ```
-    iqsharp: 0.12.20070124
+    iqsharp: 0.12.20072018
     Jupyter Core: 1.4.0.0
     ```
 
@@ -212,7 +212,7 @@ The update procedure depends on whether you originally installed using conda or 
 
     ```
     Name: qsharp
-    Version: 0.12.20070124
+    Version: 0.12.20072018
     Summary: Python client for Q#, a domain-specific quantum programming language
     ...
     ```
@@ -263,7 +263,7 @@ The update procedure depends on whether you originally installed using conda or 
     Your output should be similar to the following:
 
     ```
-    iqsharp: 0.12.20070124
+    iqsharp: 0.12.20072018
     Jupyter Core: 1.4.0.0
     ```
 

--- a/articles/quickstarts/update.md
+++ b/articles/quickstarts/update.md
@@ -49,7 +49,7 @@ Regardless of whether you are using C# or Python to host Q# operations, follow t
 5. In each of the .csproj files, set the SDK to `Microsoft.Quantum.Sdk`, as indicated in the line below. Please notice that the version number should be the latest available, and you can determine it by reviewing the [release notes](https://docs.microsoft.com/quantum/relnotes/).
 
     ```xml
-    <Project Sdk="Microsoft.Quantum.Sdk/0.12.20072018">
+    <Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
     ```
 
 6. Save and close all files in your solution.
@@ -89,7 +89,7 @@ You can now skip ahead to [update your Visual Studio QDK extension](#update-visu
     dotnet clean [project_name].csproj
     ```
 
-3. Determine the current version of the QDK. To find it, you can review the [release notes](https://docs.microsoft.com/quantum/relnotes/). The version will be in a format similar to `0.12.20072018`.
+3. Determine the current version of the QDK. To find it, you can review the [release notes](https://docs.microsoft.com/quantum/relnotes/). The version will be in a format similar to `0.12.20072031`.
 
 4. In each of your `.csproj` files, go through the following steps:
 
@@ -104,7 +104,7 @@ You can now skip ahead to [update your Visual Studio QDK extension](#update-visu
     - Replace the reference to the SDK in the project definition. Make sure that the version number corresponds to the value determined in **step 3**.
 
         ```xml
-        <Project Sdk="Microsoft.Quantum.Sdk/0.12.20072018">
+        <Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
         ```
 
     - Remove the reference to package `Microsoft.Quantum.Development.Kit` if present, which will be specified in the following entry:
@@ -123,7 +123,7 @@ You can now skip ahead to [update your Visual Studio QDK extension](#update-visu
         References to packages have the following format:
 
         ```xml
-        <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20072018" />
+        <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20072031" />
         ```
 
     - Save the updated file.
@@ -190,7 +190,7 @@ The update procedure depends on whether you originally installed using conda or 
     You should see the following output:
 
     ```
-    iqsharp: 0.12.20072018
+    iqsharp: 0.12.20072031
     Jupyter Core: 1.4.0.0
     ```
 
@@ -212,7 +212,7 @@ The update procedure depends on whether you originally installed using conda or 
 
     ```
     Name: qsharp
-    Version: 0.12.2007.2018
+    Version: 0.12.2007.2031
     Summary: Python client for Q#, a domain-specific quantum programming language
     ...
     ```
@@ -263,7 +263,7 @@ The update procedure depends on whether you originally installed using conda or 
     Your output should be similar to the following:
 
     ```
-    iqsharp: 0.12.20072018
+    iqsharp: 0.12.20072031
     Jupyter Core: 1.4.0.0
     ```
 

--- a/articles/quickstarts/update.md
+++ b/articles/quickstarts/update.md
@@ -212,7 +212,7 @@ The update procedure depends on whether you originally installed using conda or 
 
     ```
     Name: qsharp
-    Version: 0.12.20072018
+    Version: 0.12.2007.2018
     Summary: Python client for Q#, a domain-specific quantum programming language
     ...
     ```

--- a/articles/resources/relnotes.md
+++ b/articles/resources/relnotes.md
@@ -17,9 +17,9 @@ For installation instructions, please refer to the [install guide](xref:microsof
 For update instructions, please refer to the [update guide](xref:microsoft.quantum.update).
 
 
-## Version 0.12.20072018
+## Version 0.12.20072031
 
-*Release date: July 20th, 2020*
+*Release date: July 21st, 2020*
 
 This release contains the following:
 


### PR DESCRIPTION
The sample versions in the update article are still showing the four-group version format.

To avoid confusions, updating the example versions with the current release in progress version number, which is already using the new format.