### PR TITLE
No-loc string with 'Q#' on all files

### DIFF
--- a/articles/concepts/advanced-matrices.md
+++ b/articles/concepts/advanced-matrices.md
@@ -6,7 +6,7 @@ uid: microsoft.quantum.concepts.matrix-advanced
 ms.author: nawiebe@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
-no-loc: ['$$', "$$", '$', "$", $, $$, "$$$", '$$$', $$$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
+no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, "$$$", '$$$', $$$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 # Advanced Matrix Concepts #
 

--- a/articles/concepts/circuits.md
+++ b/articles/concepts/circuits.md
@@ -6,7 +6,7 @@ uid: microsoft.quantum.concepts.circuits
 ms.author: nawiebe@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
-no-loc: ['$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
+no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 
 # Quantum Circuits

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -6,7 +6,7 @@ uid: microsoft.quantum.concepts.dirac
 ms.author: nawiebe@microsoft.com 
 ms.date: 12/11/2017
 ms.topic: article
-no-loc: ['$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
+no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 
 # Dirac Notation

--- a/articles/concepts/index.md
+++ b/articles/concepts/index.md
@@ -6,6 +6,7 @@ ms.author: nawiebe
 uid: microsoft.quantum.concepts.intro
 ms.date: 12/11/2017
 ms.topic: article
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum computing history and background

--- a/articles/concepts/multiple-qubits.md
+++ b/articles/concepts/multiple-qubits.md
@@ -6,7 +6,7 @@ uid: microsoft.quantum.concepts.multiple-qubits
 ms.author: nawiebe@microsoft.com 
 ms.date: 12/11/2017
 ms.topic: article
-no-loc: ['$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
+no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 
 # Multiple Qubits

--- a/articles/concepts/oracles.md
+++ b/articles/concepts/oracles.md
@@ -7,7 +7,7 @@ uid: microsoft.quantum.concepts.oracles
 ms.author: Christopher.Granade@microsoft.com
 ms.date: 07/11/2018
 ms.topic: article
-no-loc: ['$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
+no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 # Quantum Oracles
 

--- a/articles/concepts/pauli-measurements.md
+++ b/articles/concepts/pauli-measurements.md
@@ -6,7 +6,7 @@ uid: microsoft.quantum.concepts.pauli
 ms.author: nawiebe@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
-no-loc: ['$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
+no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 
 # Pauli Measurements

--- a/articles/concepts/the-qubit.md
+++ b/articles/concepts/the-qubit.md
@@ -6,7 +6,7 @@ uid: microsoft.quantum.concepts.qubit
 ms.author: nawiebe@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
-no-loc: ['$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
+no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 # The Qubit
 

--- a/articles/concepts/vectors-and-matrices.md
+++ b/articles/concepts/vectors-and-matrices.md
@@ -6,7 +6,7 @@ uid: microsoft.quantum.concepts.vectors
 ms.author: nawiebe@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
-no-loc: ['$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
+no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 
 # Vectors and Matrices

--- a/articles/license.md
+++ b/articles/license.md
@@ -5,7 +5,7 @@ description: License terms, disclaimers and user rights for the Microsoft Quantu
 author: QuantumWriter
 ms.author: cpalmer
 ms.date: 11/04/2019
-
+no-loc: ['Q#', '$$v']
 ---
 
 # MICROSOFT SOFTWARE LICENSE TERMS 

--- a/articles/overview/algebra-for-quantum-computing.md
+++ b/articles/overview/algebra-for-quantum-computing.md
@@ -6,6 +6,7 @@ ms.author:  bradben
 ms.date: 5/5/2020
 ms.topic: overview
 uid: microsoft.quantum.overview.algebra
+no-loc: ['Q#', '$$v']
 ---
 
 # Linear algebra for quantum computing

--- a/articles/overview/overview.md
+++ b/articles/overview/overview.md
@@ -6,6 +6,7 @@ ms.author:  bradben
 ms.date: 05/05/2020
 ms.topic: overview
 uid: microsoft.quantum.overview.introduction
+no-loc: ['Q#', '$$v']
 ---
 
 # Introduction to quantum computing and the Quantum Development Kit

--- a/articles/overview/quantum-computers-and-simulators.md
+++ b/articles/overview/quantum-computers-and-simulators.md
@@ -6,6 +6,7 @@ ms.author:  bradben
 ms.date: 5/5/2020
 ms.topic: overview
 uid: microsoft.quantum.overview.simulators
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum computers and quantum simulators

--- a/articles/overview/understanding-quantum-computing.md
+++ b/articles/overview/understanding-quantum-computing.md
@@ -6,6 +6,7 @@ ms.author:  bradben
 ms.date: 5/5/2020
 ms.topic: overview
 uid: microsoft.quantum.overview.understanding
+no-loc: ['Q#', '$$v']
 ---
 
 # Understanding quantum computing

--- a/articles/overview/what-is-qsharp-and-qdk.md
+++ b/articles/overview/what-is-qsharp-and-qdk.md
@@ -6,6 +6,7 @@ ms.author:  bradben
 ms.date: 5/5/2020
 ms.topic: overview
 uid: microsoft.quantum.overview.q-sharp
+no-loc: ['Q#', '$$v']
 ---
 
 # What are the Q# programming language and QDK?

--- a/articles/quickstarts/get-started.md
+++ b/articles/quickstarts/get-started.md
@@ -6,6 +6,7 @@ author: bradben
 ms.author: bradben
 ms.date: 5/10/2020
 ms.topic: overview
+no-loc: ['Q#', '$$v']
 ---
 
 # Get started with the Quantum Development Kit (QDK)

--- a/articles/quickstarts/index.md
+++ b/articles/quickstarts/index.md
@@ -7,6 +7,7 @@ ms.date: 5/8/2020
 ms.topic: article
 ms.custom: how-to
 uid: microsoft.quantum.install
+no-loc: ['Q#', '$$v']
 ---
 
 # Install the Microsoft Quantum Development Kit (QDK)

--- a/articles/quickstarts/install-command-line.md
+++ b/articles/quickstarts/install-command-line.md
@@ -6,6 +6,7 @@ ms.date: 4/24/2020
 ms.topic: article
 ms.custom: how-to
 uid: microsoft.quantum.install.standalone
+no-loc: ['Q#', '$$v']
 ---
 
 # Develop with Q# command line applications

--- a/articles/quickstarts/install-cs.md
+++ b/articles/quickstarts/install-cs.md
@@ -6,6 +6,7 @@ ms.date: 5/30/2020
 ms.topic: article
 ms.custom: how-to
 uid: microsoft.quantum.install.cs
+no-loc: ['Q#', '$$v']
 ---
 # Develop with Q# and .NET
 

--- a/articles/quickstarts/install-jupyter.md
+++ b/articles/quickstarts/install-jupyter.md
@@ -6,6 +6,7 @@ ms.date: 5/30/2020
 ms.topic: article
 ms.custom: how-to
 uid: microsoft.quantum.install.jupyter
+no-loc: ['Q#', '$$v']
 ---
 
 # Develop with Q# Jupyter Notebooks

--- a/articles/quickstarts/install-python.md
+++ b/articles/quickstarts/install-python.md
@@ -6,6 +6,7 @@ ms.date: 5/30/2020
 ms.topic: article
 ms.custom: how-to
 uid: microsoft.quantum.install.python
+no-loc: ['Q#', '$$v']
 ---
 
 # Develop with Q# and Python

--- a/articles/quickstarts/update.md
+++ b/articles/quickstarts/update.md
@@ -7,6 +7,7 @@ ms.date: 5/30/2020
 ms.topic: article
 ms.custom: how-to
 uid: microsoft.quantum.update
+no-loc: ['Q#', '$$v']
 ---
 
 # Update the Microsoft Quantum Development Kit (QDK)

--- a/articles/resources/contributing/api-design-principles.md
+++ b/articles/resources/contributing/api-design-principles.md
@@ -6,6 +6,7 @@ ms.author: chgranad
 ms.date: 3/9/2020
 ms.topic: article
 uid: microsoft.quantum.contributing.api-design
+no-loc: ['Q#', '$$v']
 ---
 
 # Q# API Design Principles

--- a/articles/resources/contributing/code.md
+++ b/articles/resources/contributing/code.md
@@ -6,6 +6,7 @@ ms.author: chgranad
 ms.date: 10/12/2018
 ms.topic: article
 uid: microsoft.quantum.contributing.code
+no-loc: ['Q#', '$$v']
 ---
 
 # Contributing Code

--- a/articles/resources/contributing/docs.md
+++ b/articles/resources/contributing/docs.md
@@ -6,6 +6,7 @@ ms.author: chgranad
 ms.date: 10/12/2018
 ms.topic: article
 uid: microsoft.quantum.contributing.docs
+no-loc: ['Q#', '$$v']
 ---
 
 # Improving Documentation

--- a/articles/resources/contributing/index.md
+++ b/articles/resources/contributing/index.md
@@ -6,6 +6,7 @@ ms.author: chgranad
 ms.date: 10/12/2018
 ms.topic: article
 uid: microsoft.quantum.contributing
+no-loc: ['Q#', '$$v']
 ---
 
 # Contributing to the Quantum Development Kit

--- a/articles/resources/contributing/pull-requests.md
+++ b/articles/resources/contributing/pull-requests.md
@@ -6,6 +6,7 @@ ms.author: chgranad
 ms.date: 10/12/2018
 ms.topic: article
 uid: microsoft.quantum.contributing.pulls
+no-loc: ['Q#', '$$v']
 ---
 
 # Opening Pull Requests #

--- a/articles/resources/contributing/reporting-bugs.md
+++ b/articles/resources/contributing/reporting-bugs.md
@@ -6,6 +6,7 @@ ms.author: chgranad
 ms.date: 10/12/2018
 ms.topic: article
 uid: microsoft.quantum.contributing.reporting
+no-loc: ['Q#', '$$v']
 ---
 
 # Reporting Bugs #

--- a/articles/resources/contributing/samples.md
+++ b/articles/resources/contributing/samples.md
@@ -6,6 +6,7 @@ ms.author: chgranad
 ms.date: 10/12/2018
 ms.topic: article
 uid: microsoft.quantum.contributing.samples
+no-loc: ['Q#', '$$v']
 ---
 
 # Contributing Samples to the Quantum Development Kit

--- a/articles/resources/contributing/style-guide.md
+++ b/articles/resources/contributing/style-guide.md
@@ -6,6 +6,7 @@ ms.author: chgranad
 ms.date: 10/12/2018
 ms.topic: article
 uid: microsoft.quantum.contributing.style
+no-loc: ['Q#', '$$v']
 ---
 
 # Q# Style Guide #

--- a/articles/resources/further-reading.md
+++ b/articles/resources/further-reading.md
@@ -6,6 +6,7 @@ uid: microsoft.quantum.more-information
 ms.author: nawiebe@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
+no-loc: ['Q#', '$$v']
 ---
 
 # More quantum computing learning resources

--- a/articles/resources/glossary.md
+++ b/articles/resources/glossary.md
@@ -6,7 +6,7 @@ ms.author: Alan.Geller@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
 uid: microsoft.quantum.glossary
-no-loc: ['$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
+no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 
 # Quantum computing glossary

--- a/articles/resources/relnotes.md
+++ b/articles/resources/relnotes.md
@@ -6,6 +6,7 @@ ms.author: bradben
 ms.date: 5/30/2020
 ms.topic: article
 uid: microsoft.quantum.relnotes
+no-loc: ['Q#', '$$v']
 ---
 
 # Microsoft Quantum Development Kit Release Notes

--- a/articles/supported-macros.md
+++ b/articles/supported-macros.md
@@ -6,6 +6,7 @@ ms.author: bradben
 ms.date: 09/04/2019
 ms.topic: article
 uid: microsoft.quantum.contribute.macros
+no-loc: ['Q#', '$$v']
 ---
 
 # Supported Macros

--- a/articles/third-party-software.md
+++ b/articles/third-party-software.md
@@ -7,6 +7,7 @@ author: QuantumWriter
 ms.author: MSFT-alias-person-or-DL
 ms.date: 10/09/2017
 ms.topic: article-type-from-white-list
+no-loc: ['Q#', '$$v']
 ---
 
 # THIRD-PARTY SOFTWARE NOTICES AND INFORMATION

--- a/articles/tutorials/explore-entanglement.md
+++ b/articles/tutorials/explore-entanglement.md
@@ -6,6 +6,7 @@ ms.author: v-edsanc@microsoft.com
 ms.date: 05/29/2020
 ms.topic: tutorial
 uid: microsoft.quantum.write-program
+no-loc: ['Q#', '$$v']
 ---
 
 # Tutorial: Explore entanglement with Q\#

--- a/articles/tutorials/intro-to-katas.md
+++ b/articles/tutorials/intro-to-katas.md
@@ -6,6 +6,7 @@ ms.author: bradben
 ms.date: 06/02/2020
 ms.topic: overview
 uid: microsoft.quantum.overview.katas
+no-loc: ['Q#', '$$v']
 ---
 
 # Learn quantum computing with the Quantum Katas

--- a/articles/tutorials/quantum-random-number-generator.md
+++ b/articles/tutorials/quantum-random-number-generator.md
@@ -6,6 +6,7 @@ ms.author: megbrow@microsoft.com
 ms.date: 10/25/2019
 ms.topic: article
 uid: microsoft.quantum.quickstarts.qrng
+no-loc: ['Q#', '$$v']
 ---
 
 # Tutorial: Implement a Quantum Random Number Generator in Q\#

--- a/articles/tutorials/qubit-level.md
+++ b/articles/tutorials/qubit-level.md
@@ -5,7 +5,8 @@ author: gillenhaalb
 ms.author: a-gibec@microsoft.com
 ms.date: 10/06/2019
 uid: microsoft.quantum.circuit-tutorial
-ms.topic: tutorial 
+ms.topic: tutorial
+no-loc: ['Q#', '$$v']
 ---
 
 

--- a/articles/tutorials/search.md
+++ b/articles/tutorials/search.md
@@ -6,6 +6,7 @@ ms.author: chgranad@microsoft.com
 ms.date: 10/19/2019
 ms.topic: article
 uid: microsoft.quantum.quickstarts.search
+no-loc: ['Q#', '$$v']
 ---
 
 # Tutorial: Implement Grover's search algorithm in Q\#

--- a/articles/user-guide/basics.md
+++ b/articles/user-guide/basics.md
@@ -6,6 +6,7 @@ ms.author: a-gibec@microsoft.com
 ms.date: 02/28/2020
 ms.topic: article
 uid: microsoft.quantum.guide.basics
+no-loc: ['Q#', '$$v']
 ---
 
 # Q# Basics

--- a/articles/user-guide/host-programs.md
+++ b/articles/user-guide/host-programs.md
@@ -6,6 +6,7 @@ ms.author: a-gibec@microsoft.com
 ms.date: 05/15/2020
 ms.topic: article
 uid: microsoft.quantum.guide.host-programs
+no-loc: ['Q#', '$$v']
 ---
 
 # Ways to run a Q# program

--- a/articles/user-guide/index.md
+++ b/articles/user-guide/index.md
@@ -6,6 +6,7 @@ ms.author: a-gibec@microsoft.com
 ms.date: 03/05/2020
 ms.topic: article
 uid: microsoft.quantum.guide
+no-loc: ['Q#', '$$v']
 ---
 
 # The Q# User Guide

--- a/articles/user-guide/language/expressions.md
+++ b/articles/user-guide/language/expressions.md
@@ -6,6 +6,7 @@ ms.author: a-gibec@microsoft.com
 ms.date: 03/05/2020
 ms.topic: article
 uid: microsoft.quantum.guide.expressions
+no-loc: ['Q#', '$$v']
 ---
 
 # Type Expressions in Q#

--- a/articles/user-guide/language/types.md
+++ b/articles/user-guide/language/types.md
@@ -6,6 +6,7 @@ ms.author: a-gibec@microsoft.com
 ms.date: 03/05/2020
 ms.topic: article
 uid: microsoft.quantum.guide.types
+no-loc: ['Q#', '$$v']
 ---
 
 # Types in Q#

--- a/articles/user-guide/libraries/additional-libraries.md
+++ b/articles/user-guide/libraries/additional-libraries.md
@@ -6,6 +6,7 @@ ms.author: chgranad
 ms.date: 06/30/2020
 ms.topic: article
 uid: microsoft.quantum.libraries.using
+no-loc: ['Q#', '$$v']
 ---
 
 # Using Additional Q# Libraries

--- a/articles/user-guide/libraries/chemistry/concepts/algorithms.md
+++ b/articles/user-guide/libraries/chemistry/concepts/algorithms.md
@@ -6,6 +6,7 @@ ms.author: nawiebe@microsoft.com
 ms.date: 10/09/2017
 ms.topic: article-type-from-white-list
 uid: microsoft.quantum.chemistry.concepts.simulationalgorithms
+no-loc: ['Q#', '$$v']
 ---
 
 

--- a/articles/user-guide/libraries/chemistry/concepts/hartree-fock.md
+++ b/articles/user-guide/libraries/chemistry/concepts/hartree-fock.md
@@ -6,6 +6,7 @@ ms.author: nawiebe@microsoft.com
 ms.date: 10/09/2017
 ms.topic: article-type-from-white-list
 uid: microsoft.quantum.chemistry.concepts.hartreefock
+no-loc: ['Q#', '$$v']
 ---
 
 # Hartree–Fock Theory

--- a/articles/user-guide/libraries/chemistry/concepts/jordan-wigner.md
+++ b/articles/user-guide/libraries/chemistry/concepts/jordan-wigner.md
@@ -6,6 +6,7 @@ ms.author: nawiebe@microsoft.com
 ms.date: 10/09/2017
 ms.topic: article-type-from-white-list
 uid: microsoft.quantum.chemistry.concepts.jordanwigner
+no-loc: ['Q#', '$$v']
 ---
 
  

--- a/articles/user-guide/libraries/chemistry/concepts/multireference.md
+++ b/articles/user-guide/libraries/chemistry/concepts/multireference.md
@@ -6,6 +6,7 @@ ms.author: gulow@microsoft.com
 ms.date: 05/28/2019
 ms.topic: article-type-from-white-list
 uid: microsoft.quantum.chemistry.concepts.multireference
+no-loc: ['Q#', '$$v']
 ---
 
 # Correlated wavefunctions

--- a/articles/user-guide/libraries/chemistry/concepts/quantum-dynamics.md
+++ b/articles/user-guide/libraries/chemistry/concepts/quantum-dynamics.md
@@ -6,6 +6,7 @@ ms.author: nawiebe@microsoft.com
 ms.date: 10/09/2017
 ms.topic: article-type-from-white-list
 uid: microsoft.quantum.chemistry.concepts.quantumdynamics
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum Dynamics

--- a/articles/user-guide/libraries/chemistry/concepts/quantum-models.md
+++ b/articles/user-guide/libraries/chemistry/concepts/quantum-models.md
@@ -6,6 +6,7 @@ ms.author: nawiebe@microsoft.com
 ms.date: 10/09/2017
 ms.topic: article-type-from-white-list
 uid: microsoft.quantum.chemistry.concepts.quantummodels
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum Models for Electronic Systems

--- a/articles/user-guide/libraries/chemistry/concepts/second-quantization.md
+++ b/articles/user-guide/libraries/chemistry/concepts/second-quantization.md
@@ -6,6 +6,7 @@ ms.author: nawiebe@microsoft.com
 ms.date: 10/09/2017
 ms.topic: article-type-from-white-list
 uid: microsoft.quantum.chemistry.concepts.secondquantization
+no-loc: ['Q#', '$$v']
 ---
 
 # Second Quantization

--- a/articles/user-guide/libraries/chemistry/concepts/symmetries-molecular.md
+++ b/articles/user-guide/libraries/chemistry/concepts/symmetries-molecular.md
@@ -6,6 +6,7 @@ ms.author: nawiebe
 ms.date: 10/09/2017
 ms.topic: article-type-from-white-list
 uid: microsoft.quantum.chemistry.concepts.symmetries
+no-loc: ['Q#', '$$v']
 ---
 
 # Symmetries of Molecular Integrals

--- a/articles/user-guide/libraries/chemistry/index.md
+++ b/articles/user-guide/libraries/chemistry/index.md
@@ -6,6 +6,7 @@ ms.author: Alan.Geller@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
 uid: microsoft.quantum.chemistry.concepts.intro
+no-loc: ['Q#', '$$v']
 ---
 
 # Introduction to the Quantum Chemistry Library

--- a/articles/user-guide/libraries/chemistry/installation.md
+++ b/articles/user-guide/libraries/chemistry/installation.md
@@ -6,6 +6,7 @@ ms.author: gulow
 ms.date: 10/12/2018
 ms.topic: article
 uid: microsoft.quantum.chemistry.concepts.installation
+no-loc: ['Q#', '$$v']
 ---
 
 # Chemistry Library Installation

--- a/articles/user-guide/libraries/chemistry/samples/end-to-end.md
+++ b/articles/user-guide/libraries/chemistry/samples/end-to-end.md
@@ -5,6 +5,7 @@ author: cgranade
 ms.author: chgranad@microsoft.com
 ms.date: 10/23/2018
 uid: microsoft.quantum.chemistry.examples.endtoend
+no-loc: ['Q#', '$$v']
 ---
 
 # End-to-end with NWChem #

--- a/articles/user-guide/libraries/chemistry/samples/index.md
+++ b/articles/user-guide/libraries/chemistry/samples/index.md
@@ -6,6 +6,7 @@ ms.author: gulow
 ms.date: 10/23/2018
 ms.topic: article-type-from-white-list
 uid: microsoft.quantum.chemistry.examples
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum chemistry examples

--- a/articles/user-guide/libraries/chemistry/samples/loading-from-file.md
+++ b/articles/user-guide/libraries/chemistry/samples/loading-from-file.md
@@ -6,6 +6,7 @@ ms.author: gulow
 ms.date: 10/23/2018
 ms.topic: article-type-from-white-list
 uid: microsoft.quantum.chemistry.examples.loadhamiltonian
+no-loc: ['Q#', '$$v']
 ---
 
 # Loading a Hamiltonian from file

--- a/articles/user-guide/libraries/chemistry/samples/molecular-hydrogen.md
+++ b/articles/user-guide/libraries/chemistry/samples/molecular-hydrogen.md
@@ -6,6 +6,7 @@ ms.author: gulow
 ms.date: 07/02/2020
 ms.topic: article-type-from-white-list
 uid: microsoft.quantum.chemistry.examples.energyestimate
+no-loc: ['Q#', '$$v']
 ---
 
 # Obtaining energy level estimates

--- a/articles/user-guide/libraries/chemistry/samples/resource-counts.md
+++ b/articles/user-guide/libraries/chemistry/samples/resource-counts.md
@@ -6,6 +6,7 @@ ms.author: gulow
 ms.date: 10/23/2018
 ms.topic: article-type-from-white-list
 uid: microsoft.quantum.chemistry.examples.resourcecounts
+no-loc: ['Q#', '$$v']
 ---
 
 # Obtaining resource counts

--- a/articles/user-guide/libraries/chemistry/schema/broombridge.md
+++ b/articles/user-guide/libraries/chemistry/schema/broombridge.md
@@ -6,6 +6,7 @@ ms.author: martinro@microsoft.com
 ms.date: 10/17/2018
 ms.topic: article
 uid: microsoft.quantum.libraries.chemistry.schema.broombridge
+no-loc: ['Q#', '$$v']
 ---
 
 # Broombridge Quantum Chemistry Schema # 

--- a/articles/user-guide/libraries/chemistry/schema/spec_v_0_1.md
+++ b/articles/user-guide/libraries/chemistry/schema/spec_v_0_1.md
@@ -6,6 +6,7 @@ ms.author: chgranad@microsoft.com
 ms.date: 10/17/2018
 ms.topic: article
 uid: microsoft.quantum.libraries.chemistry.schema.spec_v_0_1
+no-loc: ['Q#', '$$v']
 ---
 
 # Broombridge Specification v0.1 #

--- a/articles/user-guide/libraries/chemistry/schema/spec_v_0_2.md
+++ b/articles/user-guide/libraries/chemistry/schema/spec_v_0_2.md
@@ -6,6 +6,7 @@ ms.author: gulow@microsoft.com
 ms.date: 05/28/2019
 ms.topic: article
 uid: microsoft.quantum.libraries.chemistry.schema.spec_v_0_2
+no-loc: ['Q#', '$$v']
 ---
 
 # Broombridge Specification v0.2 #

--- a/articles/user-guide/libraries/index.md
+++ b/articles/user-guide/libraries/index.md
@@ -6,6 +6,7 @@ ms.author: chgranad@microsoft.com
 ms.date: 10/17/2018
 ms.topic: article
 uid: microsoft.quantum.libraries
+no-loc: ['Q#', '$$v']
 ---
 
 # Overview of Q# Libraries

--- a/articles/user-guide/libraries/machine-learning/basic-classification.md
+++ b/articles/user-guide/libraries/machine-learning/basic-classification.md
@@ -6,6 +6,7 @@ ms.author: v-edsanc@microsoft.com
 ms.date: 02/16/2020
 ms.topic: article
 uid: microsoft.quantum.libraries.machine-learning.basics
+no-loc: ['Q#', '$$v']
 ---
 
 # Basic classification: Classify data with the QDK

--- a/articles/user-guide/libraries/machine-learning/design.md
+++ b/articles/user-guide/libraries/machine-learning/design.md
@@ -6,6 +6,7 @@ ms.author: v-edsanc@microsoft.com
 ms.date: 02/17/2020
 ms.topic: article
 uid: microsoft.quantum.libraries.machine-learning.design
+no-loc: ['Q#', '$$v']
 ---
 
 # Design your own classifier

--- a/articles/user-guide/libraries/machine-learning/glossary-qml.md
+++ b/articles/user-guide/libraries/machine-learning/glossary-qml.md
@@ -5,6 +5,7 @@ ms.author: alexei.bocharov@microsoft.com
 ms.date: 2/27/2020
 ms.topic: article
 uid: microsoft.quantum.libraries.machine-learning.training
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum Machine Learning glossary

--- a/articles/user-guide/libraries/machine-learning/index.md
+++ b/articles/user-guide/libraries/machine-learning/index.md
@@ -6,6 +6,7 @@ ms.author: alexeib@microsoft.com
 ms.date: 12/5/2019
 ms.topic: article
 uid: microsoft.quantum.machine-learning.concepts.intro
+no-loc: ['Q#', '$$v']
 ---
 
 # Introduction to the Quantum Machine Learning Library

--- a/articles/user-guide/libraries/machine-learning/intro.md
+++ b/articles/user-guide/libraries/machine-learning/intro.md
@@ -5,6 +5,7 @@ ms.author: alexei.bocharov@microsoft.com
 ms.date: 11/22/2019
 ms.topic: article
 uid: microsoft.quantum.libraries.machine-learning.intro
+no-loc: ['Q#', '$$v']
 ---
 
 # Introduction to Quantum Machine Learning

--- a/articles/user-guide/libraries/machine-learning/load.md
+++ b/articles/user-guide/libraries/machine-learning/load.md
@@ -6,6 +6,7 @@ ms.author: v-edsanc@microsoft.com
 ms.date: 02/16/2020
 ms.topic: article
 uid: microsoft.quantum.libraries.machine-learning.load
+no-loc: ['Q#', '$$v']
 ---
 
 # Load and classify your own datasets

--- a/articles/user-guide/libraries/numerics/index.md
+++ b/articles/user-guide/libraries/numerics/index.md
@@ -6,6 +6,7 @@ ms.author: thhaner
 ms.date: 5/14/2019
 ms.topic: article
 uid: microsoft.quantum.numerics.intro
+no-loc: ['Q#', '$$v']
 ---
 
 # Introduction to the Quantum Numerics Library

--- a/articles/user-guide/libraries/numerics/numerics.md
+++ b/articles/user-guide/libraries/numerics/numerics.md
@@ -6,6 +6,7 @@ ms.author: thhaner
 ms.date: 5/14/2019
 ms.topic: article
 uid: microsoft.quantum.numerics.usage
+no-loc: ['Q#', '$$v']
 ---
 
 # Using the Numerics library

--- a/articles/user-guide/libraries/standard/algorithms.md
+++ b/articles/user-guide/libraries/standard/algorithms.md
@@ -6,6 +6,7 @@ ms.author: martinro@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
 uid: microsoft.quantum.libraries.standard.algorithms
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum Algorithms #

--- a/articles/user-guide/libraries/standard/applications.md
+++ b/articles/user-guide/libraries/standard/applications.md
@@ -7,6 +7,7 @@ uid: microsoft.quantum.libraries.applications
 ms.author: martinro@microsoft.com 
 ms.date: 12/11/2017
 ms.topic: article
+no-loc: ['Q#', '$$v']
 ---
 
 # Applications #

--- a/articles/user-guide/libraries/standard/characterization.md
+++ b/articles/user-guide/libraries/standard/characterization.md
@@ -6,6 +6,7 @@ uid: microsoft.quantum.libraries.characterization
 ms.author: martinro@microsoft.com 
 ms.date: 12/11/2017
 ms.topic: article
+no-loc: ['Q#', '$$v']
 ---
 
 

--- a/articles/user-guide/libraries/standard/control-flow.md
+++ b/articles/user-guide/libraries/standard/control-flow.md
@@ -7,6 +7,7 @@ uid: microsoft.quantum.concepts.control-flow
 ms.author: martinro@microsoft.com 
 ms.date: 12/11/2017
 ms.topic: article
+no-loc: ['Q#', '$$v']
 # Use only one of the following. Use ms.service for services, ms.prod for on-prem. Remove the # before the relevant field.
 # For Quantum products none of these categories have been defined  yet.
 # ms.service: service-name-from-white-list

--- a/articles/user-guide/libraries/standard/convert.md
+++ b/articles/user-guide/libraries/standard/convert.md
@@ -5,6 +5,7 @@ author: cgranade
 uid: microsoft.quantum.libraries.convert
 ms.author: chgranad@microsoft.com 
 ms.topic: article
+no-loc: ['Q#', '$$v']
 ---
 
 # Type Conversions #

--- a/articles/user-guide/libraries/standard/data-structures.md
+++ b/articles/user-guide/libraries/standard/data-structures.md
@@ -6,6 +6,7 @@ uid: microsoft.quantum.libraries.data-structures
 ms.author: martinro@microsoft.com 
 ms.date: 12/11/2017
 ms.topic: article
+no-loc: ['Q#', '$$v']
 ---
 
 # Data Structures and Modeling #

--- a/articles/user-guide/libraries/standard/diagnostics.md
+++ b/articles/user-guide/libraries/standard/diagnostics.md
@@ -5,6 +5,7 @@ author: cgranade
 uid: microsoft.quantum.libraries.diagnostics
 ms.author: chgranad@microsoft.com 
 ms.topic: article
+no-loc: ['Q#', '$$v']
 ---
 
 # Diagnostics #

--- a/articles/user-guide/libraries/standard/error-correction.md
+++ b/articles/user-guide/libraries/standard/error-correction.md
@@ -7,6 +7,7 @@ uid: microsoft.quantum.libraries.error-correction
 ms.author: martinro@microsoft.com 
 ms.date: 12/11/2017
 ms.topic: article
+no-loc: ['Q#', '$$v']
 # Use only one of the following. Use ms.service for services, ms.prod for on-prem. Remove the # before the relevant field.
 # For Quantum products none of these categories have been defined  yet.
 # ms.service: service-name-from-white-list

--- a/articles/user-guide/libraries/standard/index.md
+++ b/articles/user-guide/libraries/standard/index.md
@@ -6,6 +6,7 @@ ms.author: martinro@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
 uid: microsoft.quantum.libraries.standard.intro
+no-loc: ['Q#', '$$v']
 ---
 
 # Introduction to the Q# Standard Libraries

--- a/articles/user-guide/libraries/standard/licensing.md
+++ b/articles/user-guide/libraries/standard/licensing.md
@@ -7,6 +7,7 @@ ms.author: martinro@microsoft.com
 ms.date: 2/16/2018
 ms.topic: article
 uid: microsoft.quantum.libraries.licensing
+no-loc: ['Q#', '$$v']
 # Use only one of the following. Use ms.service for services, ms.prod for on-prem. Remove the # before the relevant field.
 # For Quantum products none of these categories have been defined  yet.
 # ms.service: service-name-from-white-list

--- a/articles/user-guide/libraries/standard/math.md
+++ b/articles/user-guide/libraries/standard/math.md
@@ -5,6 +5,7 @@ author: cgranade
 uid: microsoft.quantum.libraries.math
 ms.author: chgranad@microsoft.com 
 ms.topic: article
+no-loc: ['Q#', '$$v']
 ---
 
 # Classical Mathematical Functions #

--- a/articles/user-guide/libraries/standard/prelude.md
+++ b/articles/user-guide/libraries/standard/prelude.md
@@ -7,6 +7,7 @@ ms.author: martinro@microsoft.com
 ms.date: 12/11/2017
 ms.topic: article
 uid: microsoft.quantum.libraries.standard.prelude
+no-loc: ['Q#', '$$v']
 ---
 
 # The Prelude #

--- a/articles/user-guide/machines/full-state-simulator.md
+++ b/articles/user-guide/machines/full-state-simulator.md
@@ -6,6 +6,7 @@ ms.author: anpaz@microsoft.com
 ms.date: 06/26/2020 
 ms.topic: article
 uid: microsoft.quantum.machines.full-state-simulator
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum Development Kit (QDK) full state simulator

--- a/articles/user-guide/machines/index.md
+++ b/articles/user-guide/machines/index.md
@@ -6,6 +6,7 @@ ms.author: Alan.Geller@microsoft.com
 ms.date: 6/17/2020
 ms.topic: article
 uid: microsoft.quantum.machines
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum simulators

--- a/articles/user-guide/machines/qc-trace-simulator/depth-counter.md
+++ b/articles/user-guide/machines/qc-trace-simulator/depth-counter.md
@@ -6,6 +6,7 @@ ms.author: vadym@microsoft.com
 ms.date: 06/25/2020
 ms.topic: article
 uid: microsoft.quantum.machines.qc-trace-simulator.depth-counter
+no-loc: ['Q#', '$$v']
 ---
 # Quantum trace simulator: depth counter
 

--- a/articles/user-guide/machines/qc-trace-simulator/distinct-inputs-checker.md
+++ b/articles/user-guide/machines/qc-trace-simulator/distinct-inputs-checker.md
@@ -6,6 +6,7 @@ ms.author: vadym@microsoft.com
 ms.date: 06/25/2020
 ms.topic: article
 uid: microsoft.quantum.machines.qc-trace-simulator.distinct-inputs
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum trace simulator: distinct inputs checker

--- a/articles/user-guide/machines/qc-trace-simulator/index.md
+++ b/articles/user-guide/machines/qc-trace-simulator/index.md
@@ -7,6 +7,7 @@ ms.author: vadym@microsoft.com
 ms.date: 06/25/2020 
 ms.topic: article
 uid: microsoft.quantum.machines.qc-trace-simulator.intro
+no-loc: ['Q#', '$$v']
 ---
 
 # Microsoft Quantum Development Kit (QDK) quantum trace simulator

--- a/articles/user-guide/machines/qc-trace-simulator/invalidated-qubits-use-checker.md
+++ b/articles/user-guide/machines/qc-trace-simulator/invalidated-qubits-use-checker.md
@@ -6,6 +6,7 @@ ms.author: vadym@microsoft.com
 ms.date: 06/25/2020
 ms.topic: article
 uid: microsoft.quantum.machines.qc-trace-simulator.invalidated-qubits
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum trace simulator: invalidated qubits use checker

--- a/articles/user-guide/machines/qc-trace-simulator/primitive-operations-counter.md
+++ b/articles/user-guide/machines/qc-trace-simulator/primitive-operations-counter.md
@@ -6,6 +6,7 @@ ms.author: vadym@microsoft.com
 ms.date: 06/25/2020
 ms.topic: article
 uid: microsoft.quantum.machines.qc-trace-simulator.primitive-counter
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum trace simulator: primitive operations counter

--- a/articles/user-guide/machines/qc-trace-simulator/width-counter.md
+++ b/articles/user-guide/machines/qc-trace-simulator/width-counter.md
@@ -6,6 +6,7 @@ ms.author: vadym@microsoft.com
 ms.date: 06/25/2020
 ms.topic: article
 uid: microsoft.quantum.machines.qc-trace-simulator.width-counter
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum trace simulator: width counter

--- a/articles/user-guide/machines/resources-estimator.md
+++ b/articles/user-guide/machines/resources-estimator.md
@@ -6,6 +6,7 @@ ms.author: anpaz@microsoft.com
 ms.date: 06/26/2020
 ms.topic: article
 uid: microsoft.quantum.machines.resources-estimator
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum Development Kit (QDK) resources estimator

--- a/articles/user-guide/machines/toffoli-simulator.md
+++ b/articles/user-guide/machines/toffoli-simulator.md
@@ -6,6 +6,7 @@ ms.author: ageller@microsoft.com
 ms.date: 6/25/2020
 ms.topic: article
 uid: microsoft.quantum.machines.toffoli-simulator
+no-loc: ['Q#', '$$v']
 ---
 
 # Quantum Development Kit (QDK) Toffoli simulator

--- a/articles/user-guide/quickref/index.md
+++ b/articles/user-guide/quickref/index.md
@@ -5,6 +5,7 @@ author: gillenhaalb
 ms.author:  a-gibec@microsoft.com
 ms.date: 03/05/2020
 uid: microsoft.quantum.guide.quickref
+no-loc: ['Q#', '$$v']
 ---
 
 # Quick reference pages

--- a/articles/user-guide/quickref/iqsharp.md
+++ b/articles/user-guide/quickref/iqsharp.md
@@ -5,6 +5,7 @@ author: gillenhaalb
 ms.author:  a-gibec@microsoft.com
 ms.date: 03/05/2020
 uid: microsoft.quantum.guide.quickref.iqsharp
+no-loc: ['Q#', '$$v']
 ---
 
 # IQ# Magic Commands

--- a/articles/user-guide/using-qsharp/control-flow.md
+++ b/articles/user-guide/using-qsharp/control-flow.md
@@ -6,6 +6,7 @@ ms.author: a-gibec@microsoft.com
 ms.date: 03/05/2020
 ms.topic: article
 uid: microsoft.quantum.guide.controlflow
+no-loc: ['Q#', '$$v']
 ---
 
 # Control flow in Q#

--- a/articles/user-guide/using-qsharp/file-structure.md
+++ b/articles/user-guide/using-qsharp/file-structure.md
@@ -6,6 +6,7 @@ ms.author: a-gibec@microsoft.com
 ms.date: 03/05/2020
 ms.topic: article
 uid: microsoft.quantum.guide.filestructure
+no-loc: ['Q#', '$$v']
 ---
 
 # Q# File Structure

--- a/articles/user-guide/using-qsharp/operations-functions.md
+++ b/articles/user-guide/using-qsharp/operations-functions.md
@@ -6,6 +6,7 @@ ms.author: a-gibec@microsoft.com
 ms.date: 03/05/2020
 ms.topic: article
 uid: microsoft.quantum.guide.operationsfunctions
+no-loc: ['Q#', '$$v']
 ---
 
 # Operations and Functions in Q#

--- a/articles/user-guide/using-qsharp/testing-debugging.md
+++ b/articles/user-guide/using-qsharp/testing-debugging.md
@@ -6,6 +6,7 @@ ms.author: mamykhai@microsoft.com
 ms.date: 06/01/2020
 ms.topic: article
 uid: microsoft.quantum.guide.testingdebugging
+no-loc: ['Q#', '$$v']
 ---
 
 # Testing and debugging

--- a/articles/user-guide/using-qsharp/variables.md
+++ b/articles/user-guide/using-qsharp/variables.md
@@ -6,6 +6,7 @@ ms.author: a-gibec@microsoft.com
 ms.date: 03/05/2020
 ms.topic: article
 uid: microsoft.quantum.guide.variables
+no-loc: ['Q#', '$$v']
 ---
 
 # Variables in Q#

--- a/articles/user-guide/using-qsharp/working-with-qubits.md
+++ b/articles/user-guide/using-qsharp/working-with-qubits.md
@@ -6,6 +6,7 @@ ms.author: a-gibec@microsoft.com
 ms.date: 03/05/2020
 ms.topic: article
 uid: microsoft.quantum.guide.qubits
+no-loc: ['Q#', '$$v']
 ---
 
 # Working with qubits

--- a/tutorial-template.md
+++ b/tutorial-template.md
@@ -6,6 +6,7 @@ ms.author: bradben
 ms.date: 04/01/2020
 ms.topic: article
 uid: microsoft.quantum.tutorial-template
+no-loc: ['Q#']
 
 # title: <title should express the intent of the article. Google displays the title on the search results page, best to keep length to 60-65 characters including spaces. For example "Tutorial: Write and simulate qubit-level programs in Q#">
 # description: <Description of the tutorial for SEO - this text also appears on the search results page> 
@@ -14,6 +15,7 @@ uid: microsoft.quantum.tutorial-template
 # ms.date: 04/01/2020
 # ms.topic: tutorial
 # uid: microsoft.quantum.tutorial.<unique name for tutorial>
+# no-loc: ['Q#']
 
 # For future contributors, describe the customer intent of the tutorial
 # Customer intent: As a <type of user>, I want to <what?> so that <why>.


### PR DESCRIPTION
Added the no-loc string to metadata of all files: `no-loc: ['Q#', '$$v']`. The `'$$v'` comes from the proposed solution in #981. 

@KittyYeungQ we should merge master to live following this PR to trigger the translation

Fixes #982 and #981. 