### PR TITLE
Removed redundant row in pauli-measurements.md

### DIFF
--- a/articles/concepts/pauli-measurements.md
+++ b/articles/concepts/pauli-measurements.md
@@ -131,7 +131,6 @@ We enumerate the transformations in the following table.
 
 |Pauli Measurement     |Unitary transformation  |
 |----------------------|------------------------|
-| $Z \otimes \boldone$ | $\boldone \otimes \boldone$ |
 | $Z\otimes \boldone$ | $\boldone\otimes \boldone$ |
 | $X\otimes \boldone$ | $H\otimes \boldone$ |
 | $Y\otimes \boldone$ | $HS^\dagger\otimes \boldone$ |


### PR DESCRIPTION
I noticed that the first row in multiple-qubit measurements' table in pauli-measurements.md was redundant (as seen below), so I removed it.
![image](https://user-images.githubusercontent.com/11455681/89762973-c7682780-db06-11ea-890b-5c5df8ba2a16.png)
