### PR TITLE
Minor fix (issue 917)

### DIFF
--- a/articles/user-guide/language/types.md
+++ b/articles/user-guide/language/types.md
@@ -151,10 +151,10 @@ newtype Complex = (Double, Double);
 This statement creates a new type with two anonymous items of type `Double`.   
 
 Aside from anonymous items, user-defined types also support *named items* as of Q# version 0.7 or higher. 
-For example, you could name the items to `Re` for the double representing the real part of a complex number and `Im` for the imaginary part: 
+For example, you could name the items to `Real` for the double representing the real part of a complex number and `Imag` for the imaginary part: 
 
 ```qsharp
-newtype Complex = (Re : Double, Im : Double);
+newtype Complex = (Real : Double, Imag : Double);
 ```
 Naming one item in a user-defined type does not imply that all items need to be named - any combination of named and unnamed items is supported. 
 Furthermore, inner items may also be named.
@@ -168,18 +168,18 @@ Named items have the advantage that they can be accessed directly via the *acces
 
 ```qsharp
 function ComplexAddition(c1 : Complex, c2 : Complex) : Complex {
-    return Complex(c1::Re + c2::Re, c1::Im + c2::Im);
+    return Complex(c1::Real + c2::Real, c1::Imag + c2::Imag);
 }
 ```
 
 In addition to providing short aliases for potentially complicated tuple types, a significant advantage of defining such types is that they can document the intent of a particular value.
-Returning to the example of `Complex`, one could have also defined 2D polar coordinates as a user-defined type:
+Returning to the example of `Complex`, one could have also defined a polar coordinate represenation as a user-defined type:
 
 ```qsharp
-newtype Polar = (Radius : Double, Phase : Double);
+newtype ComplexPolar = (Magnitude : Double, Argument : Double);
 ```
 
-Even though both `Complex` and `Polar` both have an underlying type `(Double, Double)`, the two types are wholly incompatible in Q#, minimizing the risk of accidentally calling a complex math function with polar coordinates and vice versa.
+Even though both `Complex` and `ComplexPolar` both have an underlying type `(Double, Double)`, the two types are wholly incompatible in Q#, minimizing the risk of accidentally calling a complex math function with polar coordinates and vice versa.
 
 #### Access anonymous items with the unwrap operator
 


### PR DESCRIPTION
Fixes #917. 

Aligns the example type definitions to their actual definitions in the Q# lib. 