### PR TITLE
Update toc.yml

### DIFF
--- a/articles/quickstarts/toc.yml
+++ b/articles/quickstarts/toc.yml
@@ -6,7 +6,7 @@
     href: index.md
   - name: Getting started examples
     items:
-    - name: Q# applications
+    - name: Q# with Visual Studio and VS Code
       href: install-command-line.md
     - name: Q# with Jupyter Notebooks
       href: install-jupyter.md


### PR DESCRIPTION
Changed this to match with our new website design. Also we probably shouldn't have called it Q# applications in the first place as it is not consistent with the rest of the TOC titles. 