### PR TITLE
Update install-command-line.md

### DIFF
--- a/articles/quickstarts/install-command-line.md
+++ b/articles/quickstarts/install-command-line.md
@@ -56,7 +56,7 @@ To create a new project:
 
 1. Click **View** -> **Command Palette** and select **Q#: Create New Project**.
 2. Click **Standalone console application**.
-3. Navigate to the location to save the project and click **Create Project**.
+3. Navigate to the location to save the project. Enter the project name and click **Create Project**.
 4. When the project is successfully created, click **Open new project...** in the lower right.
 
 Inspect the project. You should see a source file named `Program.qs`, which is a Q# program that defines a simple operation to print a message to the console.


### PR DESCRIPTION
Addresses issue #1105:
Includes the project name in the instructions to create a new Q# project in VS Code.
Without entering a project name, the project cannot be created.