### PR TITLE
change feedback_github_repo to MS/QuantumLibraries for /api folder

### DIFF
--- a/api/docfx.json
+++ b/api/docfx.json
@@ -40,7 +40,7 @@
       "searchScope": ["quantum", "q#", "qsharp"],
       "feedback_system": "GitHub",
       "feedback_github_repo": "Microsoft/QuantumLibraries",
-      "feedback_product_url": "https://github.com/microsoft/quantum/issues",
+      "feedback_product_url": "https://github.com/microsoft/QuantumLibraries/issues",
       "titleSuffix": "Q# reference - Microsoft Quantum"
     },
     "fileMetadata": {

--- a/api/docfx.json
+++ b/api/docfx.json
@@ -39,7 +39,7 @@
       "ms.devlang":"qsharp",
       "searchScope": ["quantum", "q#", "qsharp"],
       "feedback_system": "GitHub",
-      "feedback_github_repo": "Microsoft/quantum",
+      "feedback_github_repo": "Microsoft/QuantumLibraries",
       "feedback_product_url": "https://github.com/microsoft/quantum/issues",
       "titleSuffix": "Q# reference - Microsoft Quantum"
     },


### PR DESCRIPTION
This resolves https://github.com/MicrosoftDocs/quantum-docs-pr/issues/1120 and redirects issues to the `QuantumLibraries` repo instead of `Quantum`.