### PR TITLE
Q-language docs: Update links and TOCs

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -689,41 +689,42 @@
       "source_path": "articles/user-guide/libraries/numerics/installation.md",
       "redirect_url": "/quantum/user-guide/libraries/numerics/index",
       "redirect_document_id": false
-    }
+    },
     {
       "source_path": "/quantum/user-guide/basics.md",
       "redirect_url": "/quantum/user-guide/programs",
       "redirect_document_id": true
-    }
+    },
     {
       "source_path": "/quantum/user-guide/language/expressions.md",
       "redirect_url": "/quantum/user-guide/language/expressions/index",
       "redirect_document_id": true
-    }
+    },
     {
       "source_path": "/quantum/user-guide/language/types.md",
       "redirect_url": "/quantum/user-guide/language/typesystem/index",
       "redirect_document_id": true
-    }
+    },
+    {
       "source_path": "/quantum/user-guide/using-qsharp/control-flow.md",
       "redirect_url": "/quantum/user-guide/language/statements/iterations",
       "redirect_document_id": true
-    }
+    },
     {
       "source_path": "/quantum/user-guide/using-qsharp/file-structure.md",
       "redirect_url": "/quantum/user-guide/language/programstructure/index",
       "redirect_document_id": true
-    }
+    },
     {
       "source_path": "/quantum/user-guide/using-qsharp/operations-functions.md",
       "redirect_url": "/quantum/user-guide/language/typesystem/operationsandfunctions",
       "redirect_document_id": true
-    }
+    },
     {
       "source_path": "/quantum/user-guide/using-qsharp/variables.md",
       "redirect_url": "/quantum/user-guide/language/typesystem/index",
       "redirect_document_id": true
-    }
+    },
     {
       "source_path": "/quantum/user-guide/using-qsharp/working-with-qubits.md",
       "redirect_url": "/quantum/user-guide/language/typesystem/quantumdatatypes",

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -82,27 +82,27 @@
     },
     {
       "source_path": "articles/quantum-techniques-1-Qsharp_FileStructure.md",
-      "redirect_url": "/quantum/user-guide/basics",
+      "redirect_url": "/quantum/user-guide/programs",
       "redirect_document_id": false
     },
     {
       "source_path": "articles/quantum-techniques-2-OperationsandFunctions.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/operations-functions",
+      "redirect_url": "/quantum/user-guide/language/typesystem/operationsandfunctions",
       "redirect_document_id": false
     },
     {
       "source_path": "articles/quantum-techniques-3-LocalVariables.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/variables",
+      "redirect_url": "/quantum/user-guide/language/typesystem/index",
       "redirect_document_id": false
     },
     {
       "source_path": "articles/quantum-techniques-4-TypeModel.md",
-      "redirect_url": "/quantum/user-guide/language/types",
+      "redirect_url": "/quantum/user-guide/language/typesystem/index",
       "redirect_document_id": false
     },
     {
       "source_path": "articles/quantum-techniques-5-WorkingWithQubits.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/working-with-qubits",
+      "redirect_url": "/quantum/user-guide/language/typesystem/quantumdatatypes",
       "redirect_document_id": false
     },
     {
@@ -112,7 +112,7 @@
     },
     {
       "source_path": "articles/quantum-techniques-7-going-further.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/operations-functions",
+      "redirect_url": "/quantum/user-guide/language/typesystem/operationsandfunctions",
       "redirect_document_id": false
     },
     {
@@ -157,22 +157,22 @@
     },
     {
       "source_path": "articles/quantum-QR-TypeModel.md",
-      "redirect_url": "/quantum/user-guide/language/types",
+      "redirect_url": "/quantum/user-guide/language/typesystem/index",
       "redirect_document_id": false
     },
     {
       "source_path": "articles/quantum-QR-Expressions.md",
-      "redirect_url": "/quantum/user-guide/language/expressions",
+      "redirect_url": "/quantum/user-guide/language/expressions/index",
       "redirect_document_id": false
     },
     {
       "source_path": "articles/quantum-QR-Statements.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/control-flow",
+      "redirect_url": "/quantum/user-guide/language/statements/iterations",
       "redirect_document_id": false
     },
     {
       "source_path": "articles/quantum-QR-FileStructure.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/file-structure",
+      "redirect_url": "/quantum/user-guide/language/programstructure/index",
       "redirect_document_id": false
     },
     {
@@ -222,48 +222,48 @@
     },
     {
       "source_path": "articles/techniques/file-structure.md",
-      "redirect_url": "/quantum/user-guide/basics",
+      "redirect_url": "/quantum/user-guide/language/programstructure/index",
       "redirect_document_id": true
     },
     {
       "source_path": "articles/language/type-model.md",
-      "redirect_url": "/quantum/user-guide/language/types",
-      "redirect_document_id": true
+      "redirect_url": "/quantum/user-guide/language/typesystem/index",
+      "redirect_document_id": false
     },
     {
       "source_path": "articles/language/expressions.md",
-      "redirect_url": "/quantum/user-guide/language/expressions",
-      "redirect_document_id": true
+      "redirect_url": "/quantum/user-guide/language/expressions/index",
+      "redirect_document_id": false
     },
     {
       "source_path": "articles/language/file-structure.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/file-structure",
-      "redirect_document_id": true
+      "redirect_url": "/quantum/user-guide/language/programstructure/index",
+      "redirect_document_id": false
     },
     {
       "source_path": "articles/techniques/operations-and-functions.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/operations-functions",
+      "redirect_url": "/quantum/user-guide/language/typesystem/operationsandfunctions",
       "redirect_document_id": true
     },
     {
       "source_path": "articles/techniques/going-further.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/operations-functions",
+      "redirect_url": "/quantum/user-guide/language/typesystem/operationsandfunctions",
       "redirect_document_id": false
     },
     {
       "source_path": "articles/techniques/local-variables.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/variables",
-      "redirect_document_id": true
+      "redirect_url": "/quantum/user-guide/language/typesystem/index",
+      "redirect_document_id": false
     },
     {
       "source_path": "articles/techniques/working-with-qubits.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/working-with-qubits",
-      "redirect_document_id": true
+      "redirect_url": "/quantum/user-guide/language/typesystem/quantumdatatypes",
+      "redirect_document_id": false
     },
     {
       "source_path": "articles/language/statements.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/control-flow",
-      "redirect_document_id": true
+      "redirect_url": "/quantum/user-guide/language/statements/iterations",
+      "redirect_document_id": false
     },
     {
       "source_path": "articles/techniques/testing-and-debugging.md",
@@ -690,5 +690,45 @@
       "redirect_url": "/quantum/user-guide/libraries/numerics/index",
       "redirect_document_id": false
     }
+    {
+      "source_path": "/quantum/user-guide/basics.md",
+      "redirect_url": "/quantum/user-guide/programs",
+      "redirect_document_id": true
+    }
+    {
+      "source_path": "/quantum/user-guide/language/expressions.md",
+      "redirect_url": "/quantum/user-guide/language/expressions/index",
+      "redirect_document_id": true
+    }
+    {
+      "source_path": "/quantum/user-guide/language/types.md",
+      "redirect_url": "/quantum/user-guide/language/typesystem/index",
+      "redirect_document_id": true
+    }
+      "source_path": "/quantum/user-guide/using-qsharp/control-flow.md",
+      "redirect_url": "/quantum/user-guide/language/statements/iterations",
+      "redirect_document_id": true
+    }
+    {
+      "source_path": "/quantum/user-guide/using-qsharp/file-structure.md",
+      "redirect_url": "/quantum/user-guide/language/programstructure/index",
+      "redirect_document_id": true
+    }
+    {
+      "source_path": "/quantum/user-guide/using-qsharp/operations-functions.md",
+      "redirect_url": "/quantum/user-guide/language/typesystem/operationsandfunctions",
+      "redirect_document_id": true
+    }
+    {
+      "source_path": "/quantum/user-guide/using-qsharp/variables.md",
+      "redirect_url": "/quantum/user-guide/language/typesystem/index",
+      "redirect_document_id": true
+    }
+    {
+      "source_path": "/quantum/user-guide/using-qsharp/working-with-qubits.md",
+      "redirect_url": "/quantum/user-guide/language/typesystem/quantumdatatypes",
+      "redirect_document_id": true
+    }
   ]
 }
+

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -117,7 +117,7 @@
     },
     {
       "source_path": "articles/quantum-techniques-TestingAndDebugging.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/testing-debugging",
+      "redirect_url": "/quantum/user-guide/testing-debugging",
       "redirect_document_id": false
     },
     {
@@ -267,7 +267,7 @@
     },
     {
       "source_path": "articles/techniques/testing-and-debugging.md",
-      "redirect_url": "/quantum/user-guide/using-qsharp/testing-debugging",
+      "redirect_url": "/quantum/user-guide/testing-debugging",
       "redirect_document_id": true
     },
     {

--- a/articles/user-guide/host-programs.md
+++ b/articles/user-guide/host-programs.md
@@ -158,7 +158,7 @@ Now, a call of `dotnet run` from the command prompt leads to `MeasureSuperpositi
 So, you will see either `One` or `Zero` printed. 
 
 Note that it doesn't matter if you have more callables defined below it, only `MeasureSuperposition` will be run.
-Additionally, it's no problem if your callable includes [documentation comments](xref:microsoft.quantum.qsharp.comments) before its declaration, the `@EntryPoint()` attribute can be simply placed above them.
+Additionally, it's no problem if your callable includes [documentation comments](xref:microsoft.quantum.qsharp.comments#documentation-comments) before its declaration, the `@EntryPoint()` attribute can be simply placed above them.
 
 ### Callable arguments
 

--- a/articles/user-guide/host-programs.md
+++ b/articles/user-guide/host-programs.md
@@ -59,7 +59,7 @@ However, it requires a few more additions to comprise a full `*.qs` Q# file.
 
 All Q# types and callables (both those you define and those intrinsic to the language) are defined within *namespaces*, which provide each a full name that can then be referenced.
 
-For example, the [`H`](xref:Microsoft.Quantum.Intrinsic.H) and [`MResetZ`](xref:Microsoft.Quantum.Measurement.MResetZ) operations are found in the [`Microsoft.Quantum.Instrinsic`](xref:Microsoft.Quantum.Intrinsic) and [`Microsoft.Quantum.Measurement`](xref:Microsoft.Quantum.Measurement) namespaces (part of the [Q# Standard Libraries](xref:microsoft.quantum.qsharplibintro)).
+For example, the [`H`](xref:Microsoft.Quantum.Intrinsic.H) and [`MResetZ`](xref:Microsoft.Quantum.Measurement.MResetZ) operations are found in the [`Microsoft.Quantum.Instrinsic`](xref:Microsoft.Quantum.Intrinsic) and [`Microsoft.Quantum.Measurement`](xref:Microsoft.Quantum.Measurement) namespaces (part of the [Q# Standard Libraries](xref:microsoft.quantum.libraries.standard.intro)).
 As such, they can always be called via their *full* names, `Microsoft.Quantum.Intrinsic.H(<qubit>)` and `Microsoft.Quantum.Measurement.MResetZ(<qubit>)`, but always doing this would lead to very cluttered code.
 
 Instead, `open` statements allow callables to be referenced with more concise shorthand, as we've done in the operation body above.
@@ -600,7 +600,7 @@ Here, we will detail how to run the Q# operations defined above, but a more broa
 
 In a Q# Jupyter Notebook, you enter Q# code just as we would from inside the namespace of a Q# file.
 
-So, we can enable access to callables from the [Q# standard libraries](xref:microsoft.quantum.qsharplibintro) with `open` statements for their respective namespaces.
+So, we can enable access to callables from the [Q# standard libraries](xref:microsoft.quantum.libraries.standard.intro) with `open` statements for their respective namespaces.
 Upon running a cell with such a statement, the definitions from those namespaces are available throughout the workspace.
 
 > [!NOTE]

--- a/articles/user-guide/host-programs.md
+++ b/articles/user-guide/host-programs.md
@@ -48,7 +48,7 @@ Hence, you can write an operation of the following form:
         }
     }
 ```
-You have defined an operation, `MeasureSuperposition`, which takes no inputs and returns a value of type [Result](xref:microsoft.quantum.qsharp.typesystem-index).
+You have defined an operation, `MeasureSuperposition`, which takes no inputs and returns a value of type [Result](xref:microsoft.quantum.qsharp.typesystem-index#available-types).
 
 In addition to operations, Q# also allows to encapsulate deterministic computations into functions. Aside from the determinism guarantee that implies that computations that act on qubits need to be encapsulated into operations rather than functions, there is little difference between operations and function. We refer to them collectively as *callables*.
 

--- a/articles/user-guide/host-programs.md
+++ b/articles/user-guide/host-programs.md
@@ -38,7 +38,7 @@ In Q#, this would be performed by the following code:
 ```
 
 However, this code alone can't be run by Q#.
-For that, it needs to make up the body of an [operation](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/4_TypeSystem/OperationsAndFunctions.md), which is then run when called---either directly or by another operation. 
+For that, it needs to make up the body of an [operation](xref:microsoft.quantum.qsharp.operationsandfunctions), which is then run when called---either directly or by another operation. 
 Hence, you can write an operation of the following form:
 ```qsharp
     operation MeasureSuperposition() : Result {
@@ -48,7 +48,7 @@ Hence, you can write an operation of the following form:
         }
     }
 ```
-You have defined an operation, `MeasureSuperposition`, which takes no inputs and returns a value of type [Result](https://github.com/microsoft/qsharp-language/tree/main/Specifications/Language/4_TypeSystem#available-types).
+You have defined an operation, `MeasureSuperposition`, which takes no inputs and returns a value of type [Result](xref:microsoft.quantum.qsharp.typesystem-index).
 
 In addition to operations, Q# also allows to encapsulate deterministic computations into functions. Aside from the determinism guarantee that implies that computations that act on qubits need to be encapsulated into operations rather than functions, there is little difference between operations and function. We refer to them collectively as *callables*.
 
@@ -158,7 +158,7 @@ Now, a call of `dotnet run` from the command prompt leads to `MeasureSuperpositi
 So, you will see either `One` or `Zero` printed. 
 
 Note that it doesn't matter if you have more callables defined below it, only `MeasureSuperposition` will be run.
-Additionally, it's no problem if your callable includes [documentation comments](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/1_ProgramStructure/7_Comments.md#documentation-comments) before its declaration, the `@EntryPoint()` attribute can be simply placed above them.
+Additionally, it's no problem if your callable includes [documentation comments](xref:microsoft.quantum.qsharp.comments) before its declaration, the `@EntryPoint()` attribute can be simply placed above them.
 
 ### Callable arguments
 

--- a/articles/user-guide/index.md
+++ b/articles/user-guide/index.md
@@ -15,7 +15,7 @@ Welcome to the Q# User Guide!
 
 In the different topics of this guide, we introduce some of the basics for developing quantum programs using Q#.
 
-We refer to the [Q# GitHub repository](https://github.com/microsoft/qsharp-language/tree/main/Specifications/Language#q-language) for a full specification and documentation of the Q# quantum programming language. 
+We refer to the [Q# language guide](xref:microsoft.quantum.qsharp.index) for a full specification and documentation of the Q# quantum programming language. 
 
 ## User Guide Contents
 

--- a/articles/user-guide/language/Expressions/toc.yml
+++ b/articles/user-guide/language/Expressions/toc.yml
@@ -30,5 +30,3 @@
   href: contextualexpressions.md
 - name: Value literals and default values
   href: valueliterals.md
-- name: Identifiers
-  href: identifiers.md

--- a/articles/user-guide/language/ProgramStructure/toc.yml
+++ b/articles/user-guide/language/ProgramStructure/toc.yml
@@ -8,9 +8,5 @@
   href: callabledeclarations.md
 - name: Specialization declarations
   href: specializationdeclarations.md
-- name: Attributes
-  href: attributes.md
-- name: Access modifiers
-  href: accessmodifiers.md
 - name: Comments
   href: comments.md

--- a/articles/user-guide/language/TypeSystem/toc.yml
+++ b/articles/user-guide/language/TypeSystem/toc.yml
@@ -10,5 +10,3 @@
   href: subtypingandvariance.md
 - name: Type parameterizations
   href: typeparameterizations.md
-- name: Type inference
-  href: typeinference.md

--- a/articles/user-guide/language/toc.yml
+++ b/articles/user-guide/language/toc.yml
@@ -1,4 +1,4 @@
-- name: Q# language
+- name: Overview
   href: index.md
 - name: Program structure
   href: programstructure/toc.yml

--- a/articles/user-guide/language/toc.yml
+++ b/articles/user-guide/language/toc.yml
@@ -1,0 +1,12 @@
+- name: Q# language
+  href: index.md
+- name: Program structure
+  href: programstructure/toc.yml
+- name: Statements
+  href: statements/toc.yml 
+- name: Expressions
+  href: expressions/toc.yml
+- name: Type system
+  href: typesystem/toc.yml
+- name: Grammar
+  href: grammar.md

--- a/articles/user-guide/programs.md
+++ b/articles/user-guide/programs.md
@@ -10,7 +10,7 @@ uid: microsoft.quantum.guide.programs
 
 # Q# Quantum Programming Language
 
-Everything you need to know about the Q# programming language is detailed on the [Q# GitHub repository](https://github.com/microsoft/qsharp-language/tree/main/Specifications/Language#q-language). 
+Everything you need to know about the Q# programming language is detailed in the [Q# language guide](xref:microsoft.quantum.qsharp.index). 
 Like anything else, our [language design process](https://github.com/microsoft/qsharp-language#q-language-and-core-libraries-design) is open source and we welcome contributions.
 For more background about the foundations and motivation behind Q#, see [Why do we need Q#?](https://devblogs.microsoft.com/qsharp/why-do-we-need-q/).  
 Q# is shipped as part of the Quantum Development Kit (QDK) For a quick overview, check out [What is the QDK?](xref:microsoft.quantum.overview.q-sharp). 
@@ -53,7 +53,7 @@ operation MeasureOneQubit() : Result {
 }
 ```
 
-Our [Quantum Katas](https://github.com/microsoft/QuantumKatas#introduction) give a good introduction on [Quantum Computing Concepts](https://github.com/microsoft/QuantumKatas#quantum-computing-concepts-qubits-and-gates) such as common quantum operations and how to manipulate qubits. 
+Our [Quantum Katas](https://.com/microsoft/QuantumKatas#introduction) give a good introduction on [Quantum Computing Concepts](https://github.com/microsoft/QuantumKatas#quantum-computing-concepts-qubits-and-gates) such as common quantum operations and how to manipulate qubits. 
 More examples can also be found in [Intrinsic Operations and Functions](xref:microsoft.quantum.libraries.standard.prelude).
 
 

--- a/articles/user-guide/programs.md
+++ b/articles/user-guide/programs.md
@@ -53,7 +53,7 @@ operation MeasureOneQubit() : Result {
 }
 ```
 
-Our [Quantum Katas](https://.com/microsoft/QuantumKatas#introduction) give a good introduction on [Quantum Computing Concepts](https://github.com/microsoft/QuantumKatas#quantum-computing-concepts-qubits-and-gates) such as common quantum operations and how to manipulate qubits. 
+Our [Quantum Katas](https://github.com/microsoft/QuantumKatas#introduction) give a good introduction on [Quantum Computing Concepts](https://github.com/microsoft/QuantumKatas#quantum-computing-concepts-qubits-and-gates) such as common quantum operations and how to manipulate qubits. 
 More examples can also be found in [Intrinsic Operations and Functions](xref:microsoft.quantum.libraries.standard.prelude).
 
 

--- a/articles/user-guide/toc.yml
+++ b/articles/user-guide/toc.yml
@@ -6,7 +6,7 @@
   href: host-programs.md
 - name: Testing and debugging
   href: testing-debugging.md
-- name: Q# language
+- name: Q# language guide
   href: language/toc.yml
 - name: Simulators and resource estimators
   href: machines/toc.yml

--- a/articles/user-guide/toc.yml
+++ b/articles/user-guide/toc.yml
@@ -4,6 +4,8 @@
   href: programs.md
 - name: Ways to run a Q# program
   href: host-programs.md
+- name: Testing and debugging
+  href: testing-debugging.md
 - name: Simulators and resource estimators
   href: machines/toc.yml
 - name: Q# libraries

--- a/articles/user-guide/toc.yml
+++ b/articles/user-guide/toc.yml
@@ -6,6 +6,8 @@
   href: host-programs.md
 - name: Testing and debugging
   href: testing-debugging.md
+- name: Q# language
+  href: language/toc.yml
 - name: Simulators and resource estimators
   href: machines/toc.yml
 - name: Q# libraries


### PR DESCRIPTION
- Update the github links to xref links in the existing topics.
- Update TOC entries for new structure
- Removed empty topics from TOC
- Updated redirects for deleted and moved topics