### PR TITLE
update ms.topic values

### DIFF
--- a/articles/concepts/advanced-matrices.md
+++ b/articles/concepts/advanced-matrices.md
@@ -5,7 +5,7 @@ author: QuantumWriter
 uid: microsoft.quantum.concepts.matrix-advanced
 ms.author: v-benbra
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, "$$$", '$$$', $$$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 # Advanced Matrix Concepts #

--- a/articles/concepts/circuits.md
+++ b/articles/concepts/circuits.md
@@ -5,7 +5,7 @@ author: QuantumWriter
 uid: microsoft.quantum.concepts.circuits
 ms.author: v-benbra
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -52,9 +52,7 @@ $$
 \ket{0} = \frac{1}{\sqrt{2}}(\ket{+} + \ket{-}),\qquad \ket{1} = \frac{1}{\sqrt{2}}(\ket{+} - \ket{-}).
 $$
 
-As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as $\braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.$
-
-This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
+As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
 These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  
 
 $$

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -45,11 +45,17 @@ $$
 \ket{+} = \frac{1}{\sqrt{2}}(\ket{0} + \ket{1}),\qquad \ket{-} = \frac{1}{\sqrt{2}}(\ket{0} - \ket{1}).
 $$
 
-This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
-These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  
+### Computational basis vectors
+This demonstrates why these states are often called a *computational basis*: every quantum state can always be expressed as sums of computational basis vectors and such sums are easily expressed using Dirac notation.  The converse is also true in that the states $\ket{+}$ and $\ket{-}$ also form a basis for quantum states.  You can see this from the fact that
 
 $$
-\big|\braket{1 | \psi}\big|^2= \left|\frac{3}{5}\braket{1 | 1} +\frac{4}{5}\braket{1 | 0}\right|^2=\frac{9}{25}.
+\ket{0} = \frac{1}{\sqrt{2}}(\ket{+} + \ket{-}),\qquad \ket{1} = \frac{1}{\sqrt{2}}(\ket{+} - \ket{-}).
+$$
+
+As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as 
+
+$$
+\braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.
 $$
 
 ### Tensor product notation

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -54,6 +54,10 @@ $$
 
 As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as 
 
+|A |B |
+|-- |-- |
+|D | E|
+
 $$
 \braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.
 $$

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -59,6 +59,7 @@ $$
 $$
 
 This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
+
 These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$ is 
 
 $$

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -54,13 +54,13 @@ $$
 
 As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as 
 
-|A |B |
-|-- |-- |
-|D | E|
-
 $$
 \braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.
 $$
+
+|A |B |
+|-- |-- |
+|D | E|
 
 This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
 These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -53,6 +53,11 @@ $$
 $$
 
 As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as 
+
+$$
+\braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.
+$$
+
 This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
 These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  
 

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -54,10 +54,6 @@ $$
 
 As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as 
 
-$$
-\braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.
-$$
-
 This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
 These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  
 

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -58,6 +58,9 @@ $$
 \braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.
 $$
 
+This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
+These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$ is  
+
 ### Tensor product notation
 Dirac notation also includes an implicit tensor product structure within it.  This is important because in quantum computing, the state vector described by two uncorrelated quantum registers is the tensor products of the two state vectors.  Concisely describing the tensor product structure, or lack thereof, is vital if you want to explain a quantum computation.  The tensor product structure implies that we can write $\psi \otimes \phi$ for any two quantum state vectors $\phi$ and $\psi$ as $\ket{\psi} \ket{\phi}$, sometimes explicitly written as $\ket{\psi} \otimes \ket{\phi}$, however by convention writing $\otimes$ in between the vectors is unnecessary.  For example, the state with two qubits initialized to the zero state is given by
 

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -52,15 +52,7 @@ $$
 \ket{0} = \frac{1}{\sqrt{2}}(\ket{+} + \ket{-}),\qquad \ket{1} = \frac{1}{\sqrt{2}}(\ket{+} - \ket{-}).
 $$
 
-As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as 
-
-$$
-\braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.
-$$
-
-|A |B |
-|-- |-- |
-|D | E|
+As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as$$\braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.$$
 
 This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
 These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -30,6 +30,21 @@ $$
 \begin{bmatrix} 0 \\\\  1 \end{bmatrix} = \ket{1}.
 $$
 
+### Example: representing the Hadamard operation with Dirac notation
+
+The following notation is often used to describe the states that result from applying the Hadamard gate to $\ket{0}$ and $\ket{1}$ (which correspond to the unit vectors in the $+x$ and $-x$ directions on the Bloch sphere):
+
+$$
+\frac{1}{\sqrt{2}}\begin{bmatrix} 1 \\\\  1 \end{bmatrix}=H\ket{0} = \ket{+},\qquad
+\frac{1}{\sqrt{2}}\begin{bmatrix} 1 \\\\  -1 \end{bmatrix} =H\ket{1} = \ket{-} .
+$$
+
+These states can also be expanded using Dirac notation as sums of $\ket{0}$ and $\ket{1}$:
+
+$$
+\ket{+} = \frac{1}{\sqrt{2}}(\ket{0} + \ket{1}),\qquad \ket{-} = \frac{1}{\sqrt{2}}(\ket{0} - \ket{1}).
+$$
+
 ### Tensor product notation
 Dirac notation also includes an implicit tensor product structure within it.  This is important because in quantum computing, the state vector described by two uncorrelated quantum registers is the tensor products of the two state vectors.  Concisely describing the tensor product structure, or lack thereof, is vital if you want to explain a quantum computation.  The tensor product structure implies that we can write $\psi \otimes \phi$ for any two quantum state vectors $\phi$ and $\psi$ as $\ket{\psi} \ket{\phi}$, sometimes explicitly written as $\ket{\psi} \otimes \ket{\phi}$, however by convention writing $\otimes$ in between the vectors is unnecessary.  For example, the state with two qubits initialized to the zero state is given by
 

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -30,23 +30,7 @@ $$
 \begin{bmatrix} 0 \\\\  1 \end{bmatrix} = \ket{1}.
 $$
 
-### Example: representing the Hadamard operation with Dirac notation
-
-The following notation is often used to describe the states that result from applying the Hadamard gate to $\ket{0}$ and $\ket{1}$ (which correspond to the unit vectors in the $+x$ and $-x$ directions on the Bloch sphere):
-
-$$
-\frac{1}{\sqrt{2}}\begin{bmatrix} 1 \\\\  1 \end{bmatrix}=H\ket{0} = \ket{+},\qquad
-\frac{1}{\sqrt{2}}\begin{bmatrix} 1 \\\\  -1 \end{bmatrix} =H\ket{1} = \ket{-} .
-$$
-
-These states can also be expanded using Dirac notation as sums of $\ket{0}$ and $\ket{1}$:
-
-$$
-\ket{+} = \frac{1}{\sqrt{2}}(\ket{0} + \ket{1}),\qquad \ket{-} = \frac{1}{\sqrt{2}}(\ket{0} - \ket{1}).
-$$
-
-### Computational basis vectors
-This demonstrates why these states are often called a *computational basis*: every quantum state can always be expressed as sums of computational basis vectors and such sums are easily expressed using Dirac notation.  The converse is also true in that the states $\ket{+}$ and $\ket{-}$ also form a basis for quantum states.  You can see this from the fact that As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
+This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
 These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  
 
 $$

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -52,7 +52,7 @@ $$
 \ket{0} = \frac{1}{\sqrt{2}}(\ket{+} + \ket{-}),\qquad \ket{1} = \frac{1}{\sqrt{2}}(\ket{+} - \ket{-}).
 $$
 
-As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as$$\braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.$$
+As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as $\braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.$
 
 This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
 These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -58,9 +58,8 @@ $$
 \braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.
 $$
 
-This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also, by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
-
-These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$, then because $\braket{1 | 0} =0$ the probability of measuring $1$ is
+This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
+These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$ is 
 
 $$
 \big|\braket{1 | \psi}\big|^2= \left|\frac{3}{5}\braket{1 | 1} +\frac{4}{5}\braket{1 | 0}\right|^2=\frac{9}{25}.

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -24,12 +24,6 @@ There are two types of vectors in Dirac notation: the *bra* vector and the *ket*
 More generally, if $\psi$ and $\phi$ are quantum state vectors their inner product is $\braket{\phi|\psi}$ which implies that the probability of measuring the state $\ket{\psi}$ to be $\ket{\phi}$ is $|\braket{\phi|\psi}|^2$.  
 
 The following convention is used to describe the quantum states that encode the values of zero and one (the single-qubit computational basis states):
-
-$$
-\begin{bmatrix} 1 \\\\  0 \end{bmatrix} = \ket{0},\qquad
-\begin{bmatrix} 0 \\\\  1 \end{bmatrix} = \ket{1}.
-$$
-
 This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
 These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  
 

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -45,19 +45,6 @@ $$
 \ket{+} = \frac{1}{\sqrt{2}}(\ket{0} + \ket{1}),\qquad \ket{-} = \frac{1}{\sqrt{2}}(\ket{0} - \ket{1}).
 $$
 
-### Computational basis vectors
-This demonstrates why these states are often called a *computational basis*: every quantum state can always be expressed as sums of computational basis vectors and such sums are easily expressed using Dirac notation.  The converse is also true in that the states $\ket{+}$ and $\ket{-}$ also form a basis for quantum states.  You can see this from the fact that
-
-$$
-\ket{0} = \frac{1}{\sqrt{2}}(\ket{+} + \ket{-}),\qquad \ket{1} = \frac{1}{\sqrt{2}}(\ket{+} - \ket{-}).
-$$
-
-As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as 
-
-$$
-\braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.
-$$
-
 This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
 These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  
 

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -46,6 +46,7 @@ $$
 $$
 
 ### Computational basis vectors
+
 This demonstrates why these states are often called a *computational basis*: every quantum state can always be expressed as sums of computational basis vectors and such sums are easily expressed using Dirac notation.  The converse is also true in that the states $\ket{+}$ and $\ket{-}$ also form a basis for quantum states.  You can see this from the fact that
 
 $$
@@ -67,6 +68,7 @@ $$
 $$
 
 ### Tensor product notation
+
 Dirac notation also includes an implicit tensor product structure within it.  This is important because in quantum computing, the state vector described by two uncorrelated quantum registers is the tensor products of the two state vectors.  Concisely describing the tensor product structure, or lack thereof, is vital if you want to explain a quantum computation.  The tensor product structure implies that we can write $\psi \otimes \phi$ for any two quantum state vectors $\phi$ and $\psi$ as $\ket{\psi} \ket{\phi}$, sometimes explicitly written as $\ket{\psi} \otimes \ket{\phi}$, however by convention writing $\otimes$ in between the vectors is unnecessary.  For example, the state with two qubits initialized to the zero state is given by
 
 $$
@@ -86,6 +88,7 @@ $$
 $$
 
 ### Example: Describing superposition with Dirac notation
+
 As another example of how you can use Dirac notation to describe a quantum state, consider the following equivalent ways of writing a quantum state that is an equal superposition over every possible bit string of length $n$
 
 $$
@@ -96,6 +99,7 @@ Here you may wonder why the sum goes from $0$ to $2^{n}-1$ for $n$ bits.  First 
 As a side note, in this example we did not use $\ket{+}^{\otimes n}=\ket{+}$ in analogy to $\ket{0}^{\otimes n} = \ket{0}$ because this notational convention is usually reserved for the computational basis state with every qubit initialized to zero.  While such a convention would be sensible in this case, it is not employed in the quantum computing literature.
 
 ### Expressing linearity with Dirac notation
+
 Another nice feature of Dirac notation is the fact that it is linear.  If we wish to write for any four quantum state vectors, 
 
 $$(\alpha \ket{\psi} +\beta\ket{\phi})\otimes (\gamma \ket{\chi} + \delta \ket{\omega})= \alpha\gamma \ket{\psi}\ket{\chi} + \alpha\delta \ket{\psi}\ket{\omega}+\beta\gamma\ket{\phi}\ket{\chi}+\beta\delta\ket{\phi}\ket{\omega}.$$
@@ -111,6 +115,7 @@ $$|\braket{- | \psi}|^2= \left|\frac{1}{\sqrt{2}}(\bra{0} - \bra{1})(\frac{3}{5}
 The fact that the negative sign appears in the calculation of the probability is a manifestation of quantum interference, which is one of the mechanisms by which quantum computing gains advantages over classical computing.
 
 ## ketbra or outer product
+
 The final item worth discussing in Dirac notation is the *ketbra* or outer product.  The outer product is represented within Dirac notations as $\ket{\psi} \bra{\phi}$, and sometimes called ketbras because the bras and kets occur in the opposite order as brakets.  The outer product is defined via matrix multiplication as $\ket{\psi} \bra{\phi} = \psi \phi^\dagger$ for quantum state vectors $\psi$ and $\phi$.  The simplest, and arguably most common example of this notation, is
 
 $$
@@ -164,4 +169,5 @@ General quantum state operators, rather than vectors, are ubiquitous in some are
 For the interested reader, we recommend reading one of the reference books provided in [For more information](xref:microsoft.quantum.more-information).
 
 ## Q# gate sequences equivalent to quantum states
+
 A final point worth raising about quantum notation and the Q# programming language: at the onset of this document we mentioned that the quantum state is the fundamental object of information in quantum computing.  It may then come as a surprise that in Q# there is no notion of a quantum state.  Instead, all states are described only by the operations used to prepare them.  The previous example is an excellent illustration of this.  Rather than expressing a uniform superposition over every quantum bit string in a register, we can represent the result as $H^{\otimes n} \ket{0}$.  This exponentially shorter description of the state not only has the advantage that we can classically reason about it, but it also concisely defines the operations needed to be propagated through the software stack to implement the algorithm.  For this reason, Q# is designed to emit gate sequences rather than quantum states; however, at a theoretical level the two perspectives are equivalent.

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -53,7 +53,6 @@ $$
 $$
 
 As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as 
-
 This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
 These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  
 

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -54,12 +54,16 @@ $$
 
 As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as 
 
-$$\braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.$$
+$$
+\braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.
+$$
 
 This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
 These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  
 
-$$\big|\braket{1 | \psi}\big|^2= \left|\frac{3}{5}\braket{1 | 1} +\frac{4}{5}\braket{1 | 0}\right|^2=\frac{9}{25}.$$ 
+$$
+\big|\braket{1 | \psi}\big|^2= \left|\frac{3}{5}\braket{1 | 1} +\frac{4}{5}\braket{1 | 0}\right|^2=\frac{9}{25}.
+$$ 
 
 ### Tensor product notation
 Dirac notation also includes an implicit tensor product structure within it.  This is important because in quantum computing, the state vector described by two uncorrelated quantum registers is the tensor products of the two state vectors.  Concisely describing the tensor product structure, or lack thereof, is vital if you want to explain a quantum computation.  The tensor product structure implies that we can write $\psi \otimes \phi$ for any two quantum state vectors $\phi$ and $\psi$ as $\ket{\psi} \ket{\phi}$, sometimes explicitly written as $\ket{\psi} \otimes \ket{\phi}$, however by convention writing $\otimes$ in between the vectors is unnecessary.  For example, the state with two qubits initialized to the zero state is given by

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -5,7 +5,7 @@ author: QuantumWriter
 uid: microsoft.quantum.concepts.dirac
 ms.author: v-benbra 
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -58,8 +58,9 @@ $$
 \braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.
 $$
 
-This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
-These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$ is  
+$$
+\big|\braket{1 | \psi}\big|^2= \left|\frac{3}{5}\braket{1 | 1} +\frac{4}{5}\braket{1 | 0}\right|^2=\frac{9}{25}.
+$$
 
 ### Tensor product notation
 Dirac notation also includes an implicit tensor product structure within it.  This is important because in quantum computing, the state vector described by two uncorrelated quantum registers is the tensor products of the two state vectors.  Concisely describing the tensor product structure, or lack thereof, is vital if you want to explain a quantum computation.  The tensor product structure implies that we can write $\psi \otimes \phi$ for any two quantum state vectors $\phi$ and $\psi$ as $\ket{\psi} \ket{\phi}$, sometimes explicitly written as $\ket{\psi} \otimes \ket{\phi}$, however by convention writing $\otimes$ in between the vectors is unnecessary.  For example, the state with two qubits initialized to the zero state is given by

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -46,13 +46,7 @@ $$
 $$
 
 ### Computational basis vectors
-This demonstrates why these states are often called a *computational basis*: every quantum state can always be expressed as sums of computational basis vectors and such sums are easily expressed using Dirac notation.  The converse is also true in that the states $\ket{+}$ and $\ket{-}$ also form a basis for quantum states.  You can see this from the fact that
-
-$$
-\ket{0} = \frac{1}{\sqrt{2}}(\ket{+} + \ket{-}),\qquad \ket{1} = \frac{1}{\sqrt{2}}(\ket{+} - \ket{-}).
-$$
-
-As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
+This demonstrates why these states are often called a *computational basis*: every quantum state can always be expressed as sums of computational basis vectors and such sums are easily expressed using Dirac notation.  The converse is also true in that the states $\ket{+}$ and $\ket{-}$ also form a basis for quantum states.  You can see this from the fact that As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
 These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  
 
 $$

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -24,12 +24,11 @@ There are two types of vectors in Dirac notation: the *bra* vector and the *ket*
 More generally, if $\psi$ and $\phi$ are quantum state vectors their inner product is $\braket{\phi|\psi}$ which implies that the probability of measuring the state $\ket{\psi}$ to be $\ket{\phi}$ is $|\braket{\phi|\psi}|^2$.  
 
 The following convention is used to describe the quantum states that encode the values of zero and one (the single-qubit computational basis states):
-This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
-These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  
 
 $$
-\big|\braket{1 | \psi}\big|^2= \left|\frac{3}{5}\braket{1 | 1} +\frac{4}{5}\braket{1 | 0}\right|^2=\frac{9}{25}.
-$$ 
+\begin{bmatrix} 1 \\\\  0 \end{bmatrix} = \ket{0},\qquad
+\begin{bmatrix} 0 \\\\  1 \end{bmatrix} = \ket{1}.
+$$
 
 ### Tensor product notation
 Dirac notation also includes an implicit tensor product structure within it.  This is important because in quantum computing, the state vector described by two uncorrelated quantum registers is the tensor products of the two state vectors.  Concisely describing the tensor product structure, or lack thereof, is vital if you want to explain a quantum computation.  The tensor product structure implies that we can write $\psi \otimes \phi$ for any two quantum state vectors $\phi$ and $\psi$ as $\ket{\psi} \ket{\phi}$, sometimes explicitly written as $\ket{\psi} \otimes \ket{\phi}$, however by convention writing $\otimes$ in between the vectors is unnecessary.  For example, the state with two qubits initialized to the zero state is given by

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -45,6 +45,26 @@ $$
 \ket{+} = \frac{1}{\sqrt{2}}(\ket{0} + \ket{1}),\qquad \ket{-} = \frac{1}{\sqrt{2}}(\ket{0} - \ket{1}).
 $$
 
+### Computational basis vectors
+This demonstrates why these states are often called a *computational basis*: every quantum state can always be expressed as sums of computational basis vectors and such sums are easily expressed using Dirac notation.  The converse is also true in that the states $\ket{+}$ and $\ket{-}$ also form a basis for quantum states.  You can see this from the fact that
+
+$$
+\ket{0} = \frac{1}{\sqrt{2}}(\ket{+} + \ket{-}),\qquad \ket{1} = \frac{1}{\sqrt{2}}(\ket{+} - \ket{-}).
+$$
+
+As an example of Dirac notation, consider the braket $\braket{0 | 1}$, which is the inner product between $0$ and $1$.  It can be written as 
+
+$$
+\braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.
+$$
+
+This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
+These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$ then because $\braket{1 | 0} =0$ the probability of measuring $1$  is  
+
+$$
+\big|\braket{1 | \psi}\big|^2= \left|\frac{3}{5}\braket{1 | 1} +\frac{4}{5}\braket{1 | 0}\right|^2=\frac{9}{25}.
+$$
+
 ### Tensor product notation
 Dirac notation also includes an implicit tensor product structure within it.  This is important because in quantum computing, the state vector described by two uncorrelated quantum registers is the tensor products of the two state vectors.  Concisely describing the tensor product structure, or lack thereof, is vital if you want to explain a quantum computation.  The tensor product structure implies that we can write $\psi \otimes \phi$ for any two quantum state vectors $\phi$ and $\psi$ as $\ket{\psi} \ket{\phi}$, sometimes explicitly written as $\ket{\psi} \otimes \ket{\phi}$, however by convention writing $\otimes$ in between the vectors is unnecessary.  For example, the state with two qubits initialized to the zero state is given by
 

--- a/articles/concepts/dirac-notation.md
+++ b/articles/concepts/dirac-notation.md
@@ -58,6 +58,10 @@ $$
 \braket{0 | 1}=\begin{bmatrix} 1 & 0 \end{bmatrix}\begin{bmatrix}0\\\\ 1\end{bmatrix}=0.
 $$
 
+This says that $\ket{0}$ and $\ket{1}$ are orthogonal vectors, meaning that $\braket{0 | 1} = \braket{1 | 0} =0$.  Also, by definition $\braket{0 | 0} = \braket{1 | 1}=1$, which means that the two computational basis vectors can also be called *orthonormal*.
+
+These orthonormal properties will be useful in the following example. If we have a state $\ket{\psi} = {\frac{3}{5}} \ket{1} + {\frac{4}{5}} \ket{0}$, then because $\braket{1 | 0} =0$ the probability of measuring $1$ is
+
 $$
 \big|\braket{1 | \psi}\big|^2= \left|\frac{3}{5}\braket{1 | 1} +\frac{4}{5}\braket{1 | 0}\right|^2=\frac{9}{25}.
 $$

--- a/articles/concepts/index.md
+++ b/articles/concepts/index.md
@@ -5,7 +5,7 @@ author: QuantumWriter
 ms.author: v-benbra
 uid: microsoft.quantum.concepts.intro
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v']
 ---
 

--- a/articles/concepts/multiple-qubits.md
+++ b/articles/concepts/multiple-qubits.md
@@ -5,7 +5,7 @@ author: bradben
 uid: microsoft.quantum.concepts.multiple-qubits
 ms.author: v-benbra
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 

--- a/articles/concepts/oracles.md
+++ b/articles/concepts/oracles.md
@@ -6,7 +6,7 @@ author: cgranade
 uid: microsoft.quantum.concepts.oracles
 ms.author: chgranad
 ms.date: 07/11/2018
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 # Quantum Oracles

--- a/articles/concepts/pauli-measurements.md
+++ b/articles/concepts/pauli-measurements.md
@@ -5,7 +5,7 @@ author: bradben
 uid: microsoft.quantum.concepts.pauli
 ms.author: v-benbra
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 

--- a/articles/concepts/the-qubit.md
+++ b/articles/concepts/the-qubit.md
@@ -5,7 +5,7 @@ author: QuantumWriter
 uid: microsoft.quantum.concepts.qubit
 ms.author: v-benbra
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 # The Qubit

--- a/articles/concepts/vectors-and-matrices.md
+++ b/articles/concepts/vectors-and-matrices.md
@@ -5,7 +5,7 @@ author: QuantumWriter
 uid: microsoft.quantum.concepts.vectors
 ms.author: v-benbra
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---
 

--- a/articles/quickstarts/get-started.md
+++ b/articles/quickstarts/get-started.md
@@ -5,7 +5,7 @@ description: Learn how to start programming quantum projects in Q# with the Micr
 author: bradben
 ms.author: v-benbra
 ms.date: 9/29/2020
-ms.topic: overview
+ms.topic: quickstart
 no-loc: ['Q#', '$$v']
 ---
 

--- a/articles/quickstarts/index.md
+++ b/articles/quickstarts/index.md
@@ -4,8 +4,7 @@ description: Learn how to set up the Microsoft Quantum Development Kit for diffe
 author: bradben
 ms.author: v-benbra
 ms.date: 5/8/2020
-ms.topic: article
-ms.custom: how-to
+ms.topic: quickstart
 uid: microsoft.quantum.install
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/quickstarts/install-binder.md
+++ b/articles/quickstarts/install-binder.md
@@ -4,8 +4,7 @@ description: Learn how to create a Q# application using Binder.
 author: bradben
 ms.author: v-benbra
 ms.date: 9/03/2020
-ms.topic: article
-ms.custom: how-to
+ms.topic: quickstart
 uid: microsoft.quantum.install.binder
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/quickstarts/install-command-line.md
+++ b/articles/quickstarts/install-command-line.md
@@ -4,8 +4,7 @@ description: Learn how to create a Q# application that runs from the command pro
 author: bradben
 ms.author: v-benbra
 ms.date: 8/20/2020
-ms.topic: article
-ms.custom: how-to
+ms.topic: quickstart
 uid: microsoft.quantum.install.standalone
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/quickstarts/install-cs.md
+++ b/articles/quickstarts/install-cs.md
@@ -4,8 +4,7 @@ description: Learn how to create a Q# application using .NET languages.
 author: bradben
 ms.author: v-benbra
 ms.date: 8/20/2020
-ms.topic: article
-ms.custom: how-to
+ms.topic: quickstart
 uid: microsoft.quantum.install.cs
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/quickstarts/install-jupyter.md
+++ b/articles/quickstarts/install-jupyter.md
@@ -4,8 +4,7 @@ description: Learn how to create a Q# application using Jupyter Notebooks.
 author: bradben
 ms.author: v-benbra
 ms.date: 8/20/2020
-ms.topic: article
-ms.custom: how-to
+ms.topic: quickstart
 uid: microsoft.quantum.install.jupyter
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/quickstarts/install-python.md
+++ b/articles/quickstarts/install-python.md
@@ -4,8 +4,7 @@ description: Learn how to create a Q# application using Python.
 author: bradben
 ms.author: v-benbra
 ms.date: 8/20/2020
-ms.topic: article
-ms.custom: how-to
+ms.topic: quickstart
 uid: microsoft.quantum.install.python
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/quickstarts/update.md
+++ b/articles/quickstarts/update.md
@@ -4,8 +4,7 @@ description: Describes how to update your Q# projects and the Microsoft Quantum 
 author: bradben
 ms.author: v-benbra
 ms.date: 5/30/2020
-ms.topic: article
-ms.custom: how-to
+ms.topic: quickstart
 uid: microsoft.quantum.update
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/resources/contributing/api-design-principles.md
+++ b/articles/resources/contributing/api-design-principles.md
@@ -4,7 +4,7 @@ description: Q# API Design Principles
 author: cgranade
 ms.author: chgranad
 ms.date: 3/9/2020
-ms.topic: article
+ms.topic: contributor-guide
 uid: microsoft.quantum.contributing.api-design
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/resources/contributing/code.md
+++ b/articles/resources/contributing/code.md
@@ -4,7 +4,7 @@ description: Learn how to contribute sample and library code to the Microsoft Qu
 author: cgranade
 ms.author: chgranad
 ms.date: 10/12/2018
-ms.topic: article
+ms.topic: contributor-guide
 uid: microsoft.quantum.contributing.code
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/resources/contributing/docs.md
+++ b/articles/resources/contributing/docs.md
@@ -4,7 +4,7 @@ description: Learn how to contribute conceptual or API content to the Microsoft 
 author: cgranade
 ms.author: chgranad
 ms.date: 10/12/2018
-ms.topic: article
+ms.topic: contributor-guide
 uid: microsoft.quantum.contributing.docs
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/resources/contributing/index.md
+++ b/articles/resources/contributing/index.md
@@ -4,7 +4,7 @@ description: Learn how to contribute to the Microsoft Quantum Development Kit an
 author: cgranade
 ms.author: chgranad
 ms.date: 10/12/2018
-ms.topic: article
+ms.topic: contributor-guide
 uid: microsoft.quantum.contributing
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/resources/contributing/pull-requests.md
+++ b/articles/resources/contributing/pull-requests.md
@@ -4,7 +4,7 @@ description: Learn how to submit a GitHub pull request when you are ready to con
 author: cgranade
 ms.author: chgranad
 ms.date: 10/12/2018
-ms.topic: article
+ms.topic: contributor-guide
 uid: microsoft.quantum.contributing.pulls
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/resources/contributing/reporting-bugs.md
+++ b/articles/resources/contributing/reporting-bugs.md
@@ -4,7 +4,7 @@ description: Learn how to report bugs or issues with the Microsoft Quantum Devel
 author: cgranade
 ms.author: chgranad
 ms.date: 10/12/2018
-ms.topic: article
+ms.topic: contributor-guide
 uid: microsoft.quantum.contributing.reporting
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/resources/contributing/samples.md
+++ b/articles/resources/contributing/samples.md
@@ -4,7 +4,7 @@ description: Learn how to contribute sample code to the Microsoft Quantum Develo
 author: cgranade
 ms.author: chgranad
 ms.date: 10/12/2018
-ms.topic: article
+ms.topic: contributor-guide
 uid: microsoft.quantum.contributing.samples
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/resources/contributing/style-guide.md
+++ b/articles/resources/contributing/style-guide.md
@@ -4,7 +4,7 @@ description: Learn the naming, input, documentation and formatting conventions f
 author: cgranade
 ms.author: chgranad
 ms.date: 10/12/2018
-ms.topic: article
+ms.topic: contributor-guide
 uid: microsoft.quantum.contributing.style
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/resources/further-reading.md
+++ b/articles/resources/further-reading.md
@@ -5,7 +5,7 @@ author: bradben
 uid: microsoft.quantum.more-information
 ms.author: v-benbra
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v']
 ---
 

--- a/articles/resources/glossary.md
+++ b/articles/resources/glossary.md
@@ -4,7 +4,7 @@ description: A glossary of common terms, actions and objects used in quantum com
 author: bradben
 ms.author: v-benbra 
 ms.date: 9/1/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.glossary
 no-loc: ['Q#', '$$v', '$$', "$$", '$', "$", $, $$, '\cdots', 'bmatrix', '\ddots', '\equiv', '\sum', '\begin', '\end', '\sqrt', '\otimes', '{', '}', '\text', '\phi', '\kappa', '\psi', '\alpha', '\beta', '\gamma', '\delta', '\omega', '\bra', '\ket', '\boldone', '\\\\', '\\', '=', '\frac', '\text', '\mapsto', '\dagger', '\to', '\begin{cases}', '\end{cases}', '\operatorname', '\braket', '\id', '\expect', '\defeq', '\variance', '\dd', '&', '\begin{align}', '\end{align}', '\Lambda', '\lambda', '\Omega', '\mathrm', '\left', '\right', '\qquad', '\times', '\big', '\langle', '\rangle', '\bigg', '\Big', '|', '\mathbb', '\vec', '\in', '\texttt', '\ne', '<', '>', '\leq', '\geq', '~~', '~', '\begin{bmatrix}', '\end{bmatrix}', '\_']
 ---

--- a/articles/resources/relnotes.md
+++ b/articles/resources/relnotes.md
@@ -4,7 +4,7 @@ description: Learn about the latest updates to the Microsoft Quantum Development
 author: bradben
 ms.author: v-benbra
 ms.date: 8/30/2020
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.relnotes
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/tutorials/quantum-random-number-generator.md
+++ b/articles/tutorials/quantum-random-number-generator.md
@@ -4,7 +4,7 @@ description: Build a Q# project that demonstrates fundamental quantum concepts l
 author: bromeg
 ms.author: megbrow
 ms.date: 10/25/2019
-ms.topic: article
+ms.topic: tutorial
 uid: microsoft.quantum.quickstarts.qrng
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/tutorials/search.md
+++ b/articles/tutorials/search.md
@@ -4,7 +4,7 @@ description: Build a Q# project that demonstrates Grover's algorithm, one of the
 author: cgranade
 ms.author: chgranad
 ms.date: 10/19/2019
-ms.topic: article
+ms.topic: tutorial
 uid: microsoft.quantum.quickstarts.search
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/arithmeticexpressions.md
+++ b/articles/user-guide/language/Expressions/arithmeticexpressions.md
@@ -4,7 +4,7 @@ description: Learn about arithmetic expressions in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.arithmeticexpressions
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/bitwiseexpressions.md
+++ b/articles/user-guide/language/Expressions/bitwiseexpressions.md
@@ -4,7 +4,7 @@ description: Learn about bitwise expressions and operators in the Q# programming
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.bitwiseexpressions
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/comparativeexpressions.md
+++ b/articles/user-guide/language/Expressions/comparativeexpressions.md
@@ -4,7 +4,7 @@ description: Learn about equality comparison expressions in the Q# programming l
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.comparativeexpressions
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/concatenation.md
+++ b/articles/user-guide/language/Expressions/concatenation.md
@@ -4,7 +4,7 @@ description: Learn about concatenation expressions in the Q# programming languag
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.concatenationexpressions
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/conditionalexpressions.md
+++ b/articles/user-guide/language/Expressions/conditionalexpressions.md
@@ -4,7 +4,7 @@ description: Learn about conditional expressions in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.conditionalexpressions
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/contextualexpressions.md
+++ b/articles/user-guide/language/Expressions/contextualexpressions.md
@@ -4,7 +4,7 @@ description: Learn about types of expressions in Q# that only valid in certain c
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.contextualexpressions
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/copyandupdateexpressions.md
+++ b/articles/user-guide/language/Expressions/copyandupdateexpressions.md
@@ -4,7 +4,7 @@ description: Learn how to use copy-and-update expressions in Q#.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.copyandupdateexpressions
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/functorapplication.md
+++ b/articles/user-guide/language/Expressions/functorapplication.md
@@ -4,7 +4,7 @@ description: Learn how to use functors with callables in Q#.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.functorapplication
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/identifiers.md
+++ b/articles/user-guide/language/Expressions/identifiers.md
@@ -4,7 +4,7 @@ description: Learn about identifiers in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.identifiers
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/index.md
+++ b/articles/user-guide/language/Expressions/index.md
@@ -4,7 +4,7 @@ description: Learn about the different types of expressions in the Q# programmin
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.expressions-index
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/itemaccessexpressions.md
+++ b/articles/user-guide/language/Expressions/itemaccessexpressions.md
@@ -4,7 +4,7 @@ description: Learn about array item access and array slicing in Q#.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.itemaccessexpression
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/logicalexpressions.md
+++ b/articles/user-guide/language/Expressions/logicalexpressions.md
@@ -4,7 +4,7 @@ description: Learn about logical operators in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.logicalexpressions
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/partialapplication.md
+++ b/articles/user-guide/language/Expressions/partialapplication.md
@@ -4,7 +4,7 @@ description: Learn about using partial application with callables in Q#.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.partialapplication
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/precedenceandassociativity.md
+++ b/articles/user-guide/language/Expressions/precedenceandassociativity.md
@@ -4,7 +4,7 @@ description: Learn about operator precedence in Q#.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.precedenceandassociativity
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Expressions/valueliterals.md
+++ b/articles/user-guide/language/Expressions/valueliterals.md
@@ -4,7 +4,7 @@ description: Learn about the different types of literals in the Q# programming l
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.valueliterals
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/ProgramStructure/accessmodifiers.md
+++ b/articles/user-guide/language/ProgramStructure/accessmodifiers.md
@@ -4,7 +4,7 @@ description: Learn about access modifiers in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.accessmodifiers
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/ProgramStructure/attributes.md
+++ b/articles/user-guide/language/ProgramStructure/attributes.md
@@ -4,7 +4,7 @@ description: Learn about attributes in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.attributes
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/ProgramStructure/callabledeclarations.md
+++ b/articles/user-guide/language/ProgramStructure/callabledeclarations.md
@@ -4,7 +4,7 @@ description: Learn how operations and functions, or callables, are declared in t
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.callabledeclarations
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/ProgramStructure/comments.md
+++ b/articles/user-guide/language/ProgramStructure/comments.md
@@ -4,7 +4,7 @@ description: Learn how to use comments in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.comments
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/ProgramStructure/index.md
+++ b/articles/user-guide/language/ProgramStructure/index.md
@@ -4,7 +4,7 @@ description: Learn how to run a simple program from the command prompt in Q#.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.programstructure-index
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/ProgramStructure/namespaces.md
+++ b/articles/user-guide/language/ProgramStructure/namespaces.md
@@ -4,7 +4,7 @@ description: Learn about how namespaces are used in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.namespaces
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/ProgramStructure/specializationdeclarations.md
+++ b/articles/user-guide/language/ProgramStructure/specializationdeclarations.md
@@ -4,7 +4,7 @@ description: Learn how to declare specialization to support certain functors in 
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.specializationdeclarations
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/ProgramStructure/typedeclarations.md
+++ b/articles/user-guide/language/ProgramStructure/typedeclarations.md
@@ -4,7 +4,7 @@ description: Learn about how user-defined types are declared in the Q# programmi
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.typedeclarations
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Statements/bindingscopes.md
+++ b/articles/user-guide/language/Statements/bindingscopes.md
@@ -4,7 +4,7 @@ description: Learn about visibility of local variables in the Q# programming lan
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.bindingscopes
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Statements/callstatements.md
+++ b/articles/user-guide/language/Statements/callstatements.md
@@ -4,7 +4,7 @@ description: Learn about different ways to call operators and functions in the Q
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.callstatements
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Statements/conditionalbranching.md
+++ b/articles/user-guide/language/Statements/conditionalbranching.md
@@ -4,7 +4,7 @@ description: Learn about conditional branching and the 'if' statement in the Q# 
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.conditionalbranching
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Statements/conditionalloops.md
+++ b/articles/user-guide/language/Statements/conditionalloops.md
@@ -4,7 +4,7 @@ description: Learn about conditional loops in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.conditionalloops
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Statements/conjugations.md
+++ b/articles/user-guide/language/Statements/conjugations.md
@@ -4,7 +4,7 @@ description: Learn about using conjugations in Q# to manage memory in quantum pr
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.conjugations
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Statements/index.md
+++ b/articles/user-guide/language/Statements/index.md
@@ -4,7 +4,7 @@ description: Learn about the different types of statements in the Q# programming
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.statements-index
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Statements/iterations.md
+++ b/articles/user-guide/language/Statements/iterations.md
@@ -4,7 +4,7 @@ description: Learn about using 'for' loops in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.iterations
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Statements/quantummemorymanagement.md
+++ b/articles/user-guide/language/Statements/quantummemorymanagement.md
@@ -4,7 +4,7 @@ description: Learn about allocating and releasing quantum memory in a Q# program
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.quantummemorymanagement
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Statements/returnsandtermination.md
+++ b/articles/user-guide/language/Statements/returnsandtermination.md
@@ -4,7 +4,7 @@ description: Learn about using the 'return' and 'fail' statements in Q# to end a
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.returnsandtermination
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/Statements/variabledeclarationsandreassignments.md
+++ b/articles/user-guide/language/Statements/variabledeclarationsandreassignments.md
@@ -4,7 +4,7 @@ description: Learn about using the 'let' and 'mutable' statements to bind variab
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.variabledeclarationsandreassignments
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/TypeSystem/immutability.md
+++ b/articles/user-guide/language/TypeSystem/immutability.md
@@ -4,7 +4,7 @@ description: Learn about immutability and Q# types.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.immutability
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/TypeSystem/index.md
+++ b/articles/user-guide/language/TypeSystem/index.md
@@ -4,7 +4,7 @@ description: Learn about the type system in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.typesystem-index
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/TypeSystem/operationsandfunctions.md
+++ b/articles/user-guide/language/TypeSystem/operationsandfunctions.md
@@ -4,7 +4,7 @@ description: Learn about operations and functions in the Q# programming language
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.operationsandfunctions
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/TypeSystem/quantumdatatypes.md
+++ b/articles/user-guide/language/TypeSystem/quantumdatatypes.md
@@ -4,7 +4,7 @@ description: Learn about quantum data types in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.quantumdatatypes
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/TypeSystem/singletontupleequivalence.md
+++ b/articles/user-guide/language/TypeSystem/singletontupleequivalence.md
@@ -4,7 +4,7 @@ description: Learn about singleton tuple equivalence in the Q# programming langu
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.singletontupleequivalence
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/TypeSystem/subtypingandvariance.md
+++ b/articles/user-guide/language/TypeSystem/subtypingandvariance.md
@@ -4,7 +4,7 @@ description: Learn about type conversions in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.subtypingandvariance
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/TypeSystem/typeinference.md
+++ b/articles/user-guide/language/TypeSystem/typeinference.md
@@ -4,7 +4,7 @@ description: Learn about type inference in the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.typeinference
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/TypeSystem/typeparameterizations.md
+++ b/articles/user-guide/language/TypeSystem/typeparameterizations.md
@@ -4,7 +4,7 @@ description: Learn about type-parameterized operations and functions in the Q# p
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.typeparameterizations
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/grammar.md
+++ b/articles/user-guide/language/grammar.md
@@ -4,7 +4,7 @@ description: Learn how the Q# programming language grammar uses actions and sema
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.grammar
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/language/index.md
+++ b/articles/user-guide/language/index.md
@@ -4,7 +4,7 @@ description: Learn about the Q# programming language.
 author: bettinaheim
 ms.author: beheim
 ms.date: 10/07/2020
-ms.topic: article
+ms.topic: reference
 uid: microsoft.quantum.qsharp.index
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/concepts/algorithms.md
+++ b/articles/user-guide/libraries/chemistry/concepts/algorithms.md
@@ -4,7 +4,7 @@ description: Learn how to use Trotter-Suzuki formulas and qubitization to work w
 author: bradben
 ms.author: v-benbra
 ms.date: 10/09/2017
-ms.topic: article-type-from-white-list
+ms.topic: conceptual
 uid: microsoft.quantum.chemistry.concepts.simulationalgorithms
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/concepts/hartree-fock.md
+++ b/articles/user-guide/libraries/chemistry/concepts/hartree-fock.md
@@ -4,7 +4,7 @@ description: Learn about the Hartree–Fock theory, a simple way to construct th
 author: bradben
 ms.author: v-benbra
 ms.date: 10/09/2017
-ms.topic: article-type-from-white-list
+ms.topic: conceptual
 uid: microsoft.quantum.chemistry.concepts.hartreefock
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/concepts/jordan-wigner.md
+++ b/articles/user-guide/libraries/chemistry/concepts/jordan-wigner.md
@@ -4,7 +4,7 @@ description: Learn about the Jordan-Wigner Representation, which maps Hamiltonia
 author: bradben
 ms.author: v-benbra
 ms.date: 10/09/2017
-ms.topic: article-type-from-white-list
+ms.topic: conceptual
 uid: microsoft.quantum.chemistry.concepts.jordanwigner
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/concepts/multireference.md
+++ b/articles/user-guide/libraries/chemistry/concepts/multireference.md
@@ -4,7 +4,7 @@ description: Learn about dynamic and non-dynamic correlations in wavefunctions u
 author: guanghaolow
 ms.author: gulow
 ms.date: 05/28/2019
-ms.topic: article-type-from-white-list
+ms.topic: conceptual
 uid: microsoft.quantum.chemistry.concepts.multireference
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/concepts/quantum-dynamics.md
+++ b/articles/user-guide/libraries/chemistry/concepts/quantum-dynamics.md
@@ -4,7 +4,7 @@ description: Learn the similarities and differences between quantum dynamics and
 author: bradben
 ms.author: v-benbra
 ms.date: 10/09/2017
-ms.topic: article-type-from-white-list
+ms.topic: conceptual
 uid: microsoft.quantum.chemistry.concepts.quantumdynamics
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/concepts/quantum-models.md
+++ b/articles/user-guide/libraries/chemistry/concepts/quantum-models.md
@@ -4,7 +4,7 @@ description: Learn how molecular electronic systems are simulated using quantum 
 author: bradben
 ms.author: v-benbra
 ms.date: 10/09/2017
-ms.topic: article-type-from-white-list
+ms.topic: conceptual
 uid: microsoft.quantum.chemistry.concepts.quantummodels
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/concepts/second-quantization.md
+++ b/articles/user-guide/libraries/chemistry/concepts/second-quantization.md
@@ -4,7 +4,7 @@ description: Learn about the Second Quantization approach to modeling electronic
 author: bradben
 ms.author: v-benbra
 ms.date: 10/09/2017
-ms.topic: article-type-from-white-list
+ms.topic: conceptual
 uid: microsoft.quantum.chemistry.concepts.secondquantization
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/concepts/symmetries-molecular.md
+++ b/articles/user-guide/libraries/chemistry/concepts/symmetries-molecular.md
@@ -4,7 +4,7 @@ description: Learn about using the Q# OrbitalIntegral type to enumerate molecula
 author: bradben    
 ms.author: v-benbra
 ms.date: 10/09/2017
-ms.topic: article-type-from-white-list
+ms.topic: conceptual
 uid: microsoft.quantum.chemistry.concepts.symmetries
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/index.md
+++ b/articles/user-guide/libraries/chemistry/index.md
@@ -4,7 +4,7 @@ description: Learn about the Microsoft Quantum Chemistry Library and how it is u
 author: QuantumWriter
 ms.author: ageller
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.chemistry.concepts.intro
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/installation.md
+++ b/articles/user-guide/libraries/chemistry/installation.md
@@ -4,7 +4,7 @@ description: Learn how to install the Microsoft Quantum chemistry library and us
 author: guanghaolow
 ms.author: gulow
 ms.date: 10/12/2018
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.chemistry.concepts.installation
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/samples/end-to-end.md
+++ b/articles/user-guide/libraries/chemistry/samples/end-to-end.md
@@ -4,6 +4,7 @@ description: Using an NWChem input deck, walk through an example of getting gate
 author: cgranade
 ms.author: chgranad
 ms.date: 10/23/2018
+ms.topic: sample
 uid: microsoft.quantum.chemistry.examples.endtoend
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/samples/loading-from-file.md
+++ b/articles/user-guide/libraries/chemistry/samples/loading-from-file.md
@@ -4,7 +4,7 @@ description: Learn how to automatically generate a large Hamiltonian using the B
 author: guanghaolow
 ms.author: gulow
 ms.date: 10/23/2018
-ms.topic: article-type-from-white-list
+ms.topic: sample
 uid: microsoft.quantum.chemistry.examples.loadhamiltonian
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/samples/molecular-hydrogen.md
+++ b/articles/user-guide/libraries/chemistry/samples/molecular-hydrogen.md
@@ -4,7 +4,7 @@ description: Walk through a sample Q# program that estimates the energy level va
 author: guanghaolow
 ms.author: gulow
 ms.date: 07/02/2020
-ms.topic: article-type-from-white-list
+ms.topic: sample
 uid: microsoft.quantum.chemistry.examples.energyestimate
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/samples/resource-counts.md
+++ b/articles/user-guide/libraries/chemistry/samples/resource-counts.md
@@ -4,7 +4,7 @@ description: Learn how to obtain resource estimates using a quantum trace simula
 author: guanghaolow
 ms.author: gulow
 ms.date: 10/23/2018
-ms.topic: article-type-from-white-list
+ms.topic: sample
 uid: microsoft.quantum.chemistry.examples.resourcecounts
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/schema/broombridge.md
+++ b/articles/user-guide/libraries/chemistry/schema/broombridge.md
@@ -4,7 +4,7 @@ description: Overview of the Broombridge quantum chemistry schema, used to model
 author: martinro
 ms.author: martinro
 ms.date: 10/17/2018
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.libraries.chemistry.schema.broombridge
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/schema/spec_v_0_1.md
+++ b/articles/user-guide/libraries/chemistry/schema/spec_v_0_1.md
@@ -4,7 +4,7 @@ description: Details the specifications for the Broombridge quantum chemistry sc
 author: cgranade
 ms.author: chgranad
 ms.date: 10/17/2018
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.libraries.chemistry.schema.spec_v_0_1
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/chemistry/schema/spec_v_0_2.md
+++ b/articles/user-guide/libraries/chemistry/schema/spec_v_0_2.md
@@ -4,7 +4,7 @@ description: Details the specifications for the Broombridge quantum chemistry sc
 author: guanghaolow
 ms.author: gulow
 ms.date: 05/28/2019
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.libraries.chemistry.schema.spec_v_0_2
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/machine-learning/basic-classification.md
+++ b/articles/user-guide/libraries/machine-learning/basic-classification.md
@@ -4,7 +4,7 @@ description: Learn how to run a quantum sequential classifier written in Q# usin
 author: geduardo
 ms.author: v-edsanc
 ms.date: 02/16/2020
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.libraries.machine-learning.basics
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/machine-learning/design.md
+++ b/articles/user-guide/libraries/machine-learning/design.md
@@ -4,7 +4,7 @@ description: Learn the basic concepts of designing circuit models for the quantu
 author: geduardo
 ms.author: v-edsanc
 ms.date: 02/17/2020
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.libraries.machine-learning.design
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/machine-learning/glossary-qml.md
+++ b/articles/user-guide/libraries/machine-learning/glossary-qml.md
@@ -4,7 +4,7 @@ description: Glossary of quantum machine learning terms
 author: alexeib2
 ms.author: alexeib
 ms.date: 2/27/2020
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.libraries.machine-learning.training
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/machine-learning/index.md
+++ b/articles/user-guide/libraries/machine-learning/index.md
@@ -4,7 +4,7 @@ description: Introduction to the Quantum Machine Learning Package
 author: QuantumWriter
 ms.author: alexeib
 ms.date: 12/5/2019
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.machine-learning.concepts.intro
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/machine-learning/intro.md
+++ b/articles/user-guide/libraries/machine-learning/intro.md
@@ -4,7 +4,7 @@ description: Learn how machine learning is used on quantum systems
 author: alexeib2
 ms.author: alexeib
 ms.date: 11/22/2019
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.libraries.machine-learning.intro
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/machine-learning/load.md
+++ b/articles/user-guide/libraries/machine-learning/load.md
@@ -4,7 +4,7 @@ description: Learn how to load your own dataset to train a classifier model with
 author: geduardo
 ms.author: v-edsanc
 ms.date: 02/16/2020
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.libraries.machine-learning.load
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/numerics/index.md
+++ b/articles/user-guide/libraries/numerics/index.md
@@ -4,7 +4,7 @@ description: Introduction to the Quantum Numerics Library
 author: thomashaener
 ms.author: thhaner
 ms.date: 5/14/2019
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.numerics.intro
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/numerics/numerics.md
+++ b/articles/user-guide/libraries/numerics/numerics.md
@@ -4,7 +4,7 @@ description: Learn about the types and operations available in the Microsoft Qua
 author: thomashaener
 ms.author: thhaner
 ms.date: 5/14/2019
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.numerics.usage
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/standard/algorithms.md
+++ b/articles/user-guide/libraries/standard/algorithms.md
@@ -46,7 +46,7 @@ For background, you could start from [Standard Amplitude Amplification](https://
 The Fourier transform is a fundamental tool of classical analysis and is just as important for quantum computations.
 In addition, the efficiency of the *quantum Fourier transform* (QFT) far surpasses what is possible on a classical machine making it one of the first tools of choice when designing a quantum algorithm.
 
-As an approximate generalization of the QFT, we provide the <xref:Microsoft.Quantum.Canon.ApproximateQft> operation that allows for further optimizations by pruning rotations that aren't strictly necessary for the desired algorithmic accuracy.
+As an approximate generalization of the QFT, we provide the <xref:Microsoft.Quantum.Canon.ApproximateQFT> operation that allows for further optimizations by pruning rotations that aren't strictly necessary for the desired algorithmic accuracy.
 The approximate QFT requires the dyadic $Z$-rotation operation <xref:Microsoft.Quantum.Intrinsic.RFrac> as well as the <xref:Microsoft.Quantum.Intrinsic.H> operation.
 The input and output are assumed to be encoded in big endian encoding---that is, the qubit with index `0` is encoded in the left-most (highest) bit of the binary integer representation.
 This aligns with [ket notation](xref:microsoft.quantum.concepts.dirac), as a register of three qubits in the state $\ket{100}$ corresponds to $q_0$ being in the state $\ket{1}$ while $q_1$ and $q_2$ are both in state $\ket{0}$.

--- a/articles/user-guide/libraries/standard/algorithms.md
+++ b/articles/user-guide/libraries/standard/algorithms.md
@@ -4,7 +4,7 @@ description: Learn about fundamental quantum computing algorithms, including amp
 author: QuantumWriter
 ms.author: martinro
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.libraries.standard.algorithms
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/standard/applications.md
+++ b/articles/user-guide/libraries/standard/applications.md
@@ -214,7 +214,7 @@ The circuits to achieve such modular arithmetic have been described in the [quan
 While the circuit above corresponds to [Quantum Phase Estimation](xref:Microsoft.Quantum.Characterization.QuantumPhaseEstimation) and explicitly enables order finding, we can reduce the number of qubits required. We can either follow Beauregard's method for order finding as described 
 [on Page 8 of arXiv:quant-ph/0205095v3](https://arxiv.org/pdf/quant-ph/0205095v3.pdf#page=8), or 
 use one of the phase estimation routines available in Microsoft.Quantum.Characterization. For example, 
-[Robust Phase Estimation](xref:microsoft.quantum.characterization.robustphaseestimation) also uses one extra qubit.
+[Robust Phase Estimation](xref:Microsoft.Quantum.Characterization.RobustPhaseEstimation) also uses one extra qubit.
 
 ### Factoring ###
 The goal of factoring is to determine the two prime factors of integer $N$, where $N$ is an $n$-bit number.  

--- a/articles/user-guide/libraries/standard/applications.md
+++ b/articles/user-guide/libraries/standard/applications.md
@@ -6,7 +6,7 @@ author: QuantumWriter
 uid: microsoft.quantum.libraries.applications
 ms.author: martinro
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v']
 ---
 

--- a/articles/user-guide/libraries/standard/characterization.md
+++ b/articles/user-guide/libraries/standard/characterization.md
@@ -5,7 +5,7 @@ author: bradben
 uid: microsoft.quantum.libraries.characterization
 ms.author: martinro
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v']
 ---
 

--- a/articles/user-guide/libraries/standard/control-flow.md
+++ b/articles/user-guide/libraries/standard/control-flow.md
@@ -8,11 +8,6 @@ ms.author: martinro
 ms.date: 12/11/2017
 ms.topic: conceptual
 no-loc: ['Q#', '$$v']
-# Use only one of the following. Use ms.service for services, ms.prod for on-prem. Remove the # before the relevant field.
-# For Quantum products none of these categories have been defined  yet.
-# ms.service: service-name-from-white-list
-# ms.prod: product-name-from-white-list
-# ms.technology: tech-name-from-white-list
 ---
 
 # Higher-Order Control Flow #
@@ -178,7 +173,7 @@ U(1, time / Float(nSteps), target);
 
 At this point, we can now reason about the Trotter–Suzuki expansion *without reference to quantum mechanics at all*.
 The expansion is effectively a very particular iteration pattern motivated by $\eqref{eq:trotter-suzuki-0}$.
-This iteration pattern is implemented by <xref:Microsoft.Quantum.Canon.DecomposedIntoTimestepsCA>:
+This iteration pattern is implemented by <xref:Microsoft.Quantum.Canon.DecomposedIntoTimeStepsCA>:
 
 ```qsharp
 // The 2 indicates how many terms we need to decompose,

--- a/articles/user-guide/libraries/standard/control-flow.md
+++ b/articles/user-guide/libraries/standard/control-flow.md
@@ -6,7 +6,7 @@ author: QuantumWriter
 uid: microsoft.quantum.concepts.control-flow
 ms.author: martinro
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v']
 # Use only one of the following. Use ms.service for services, ms.prod for on-prem. Remove the # before the relevant field.
 # For Quantum products none of these categories have been defined  yet.

--- a/articles/user-guide/libraries/standard/convert.md
+++ b/articles/user-guide/libraries/standard/convert.md
@@ -4,7 +4,7 @@ description: Learn about common and user-defined type conversion functions in th
 author: cgranade
 uid: microsoft.quantum.libraries.convert
 ms.author: chgranad 
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v']
 ---
 

--- a/articles/user-guide/libraries/standard/data-structures.md
+++ b/articles/user-guide/libraries/standard/data-structures.md
@@ -5,7 +5,7 @@ author: QuantumWriter
 uid: microsoft.quantum.libraries.data-structures
 ms.author: martinro
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v']
 ---
 

--- a/articles/user-guide/libraries/standard/diagnostics.md
+++ b/articles/user-guide/libraries/standard/diagnostics.md
@@ -4,7 +4,7 @@ description: Learn about the diagnostic functions and operations in the Q# stand
 author: cgranade
 uid: microsoft.quantum.libraries.diagnostics
 ms.author: chgranad 
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v']
 ---
 

--- a/articles/user-guide/libraries/standard/error-correction.md
+++ b/articles/user-guide/libraries/standard/error-correction.md
@@ -6,7 +6,7 @@ author: QuantumWriter
 uid: microsoft.quantum.libraries.error-correction
 ms.author: martinro
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v']
 # Use only one of the following. Use ms.service for services, ms.prod for on-prem. Remove the # before the relevant field.
 # For Quantum products none of these categories have been defined  yet.

--- a/articles/user-guide/libraries/standard/error-correction.md
+++ b/articles/user-guide/libraries/standard/error-correction.md
@@ -8,11 +8,6 @@ ms.author: martinro
 ms.date: 12/11/2017
 ms.topic: conceptual
 no-loc: ['Q#', '$$v']
-# Use only one of the following. Use ms.service for services, ms.prod for on-prem. Remove the # before the relevant field.
-# For Quantum products none of these categories have been defined  yet.
-# ms.service: service-name-from-white-list
-# ms.prod: product-name-from-white-list
-# ms.technology: tech-name-from-white-list
 ---
 
 # Error Correction #

--- a/articles/user-guide/libraries/standard/index.md
+++ b/articles/user-guide/libraries/standard/index.md
@@ -4,7 +4,7 @@ description: Learn about the Microsoft Q# standard libraries that define the ope
 author: QuantumWriter
 ms.author: martinro
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.libraries.standard.intro
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/libraries/standard/licensing.md
+++ b/articles/user-guide/libraries/standard/licensing.md
@@ -5,14 +5,9 @@ description: Learn about the licensing for using and contributing to the Microso
 author: martinro
 ms.author: martinro
 ms.date: 2/16/2018
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.libraries.licensing
 no-loc: ['Q#', '$$v']
-# Use only one of the following. Use ms.service for services, ms.prod for on-prem. Remove the # before the relevant field.
-# For Quantum products none of these categories have been defined  yet.
-# ms.service: service-name-from-white-list
-# ms.prod: product-name-from-white-list
-# ms.technology: tech-name-from-white-list
 ---
 # Licensing #
 

--- a/articles/user-guide/libraries/standard/math.md
+++ b/articles/user-guide/libraries/standard/math.md
@@ -4,7 +4,7 @@ description: Learn about the classical math functions in the Q# standard librari
 author: cgranade
 uid: microsoft.quantum.libraries.math
 ms.author: chgranad
-ms.topic: article
+ms.topic: conceptual
 no-loc: ['Q#', '$$v']
 ---
 

--- a/articles/user-guide/libraries/standard/prelude.md
+++ b/articles/user-guide/libraries/standard/prelude.md
@@ -134,7 +134,7 @@ This is the square root of the <xref:Microsoft.Quantum.Intrinsic.S> operation, s
 The $T$ gate is in turn implemented by the <xref:Microsoft.Quantum.Intrinsic.T> operation, and has signature `(Qubit => Unit is Adj + Ctl)`, indicating that it is a unitary operation on a single-qubit.
 
 Even though this is in principle sufficient to describe any arbitrary single-qubit operation, different target machines may have more efficient representations for rotations about Pauli operators, such that the prelude includes a variety of ways to convienently express such rotations.
-The most basic of these is the <xref:Microsoft.Quantum.Intrinsic.r> operation, which implements a rotation around a specified Pauli axis,
+The most basic of these is the <xref:Microsoft.Quantum.Intrinsic.R> operation, which implements a rotation around a specified Pauli axis,
 \begin{equation}
     R(\sigma, \phi) \mathrel{:=}
     \exp(-i \phi \sigma / 2),
@@ -145,7 +145,7 @@ We can partially apply $\sigma$ and $\phi$ to obtain an operation whose type is 
 For example, `R(PauliZ, PI() / 4, _)` has type `(Qubit => Unit is Adj + Ctl)`.
 
 > [!NOTE]
-> The <xref:Microsoft.Quantum.Intrinsic.r> operation divides the input angle by 2 and multiplies it by -1.
+> The <xref:Microsoft.Quantum.Intrinsic.R> operation divides the input angle by 2 and multiplies it by -1.
 > For $Z$ rotations, this means that the $\ket{0}$ eigenstate is rotated by $-\phi / 2$ and the
 > $\ket{1}$ eigenstate is rotated by $\phi / 2$, so that the $\ket{1}$ eigenstate is rotated by $\phi$
 > relative to the $\ket{0}$ eigenstate.
@@ -277,7 +277,7 @@ First, since performing single-qubit measurements is quite common, the prelude d
 The <xref:Microsoft.Quantum.Intrinsic.M> operation measures the Pauli $Z$ operator on a single qubit, and has signature `(Qubit => Result)`.
 `M(q)` is equivalent to `Measure([PauliZ], [q])`.
 
-The <xref:microsoft.quantum.measurement.MultiM> measures the Pauli $Z$ operator *separately* on each of an array of qubits, returning the *array* of `Result` values obtained for each qubit.
+The <xref:Microsoft.Quantum.Measurement.MultiM> measures the Pauli $Z$ operator *separately* on each of an array of qubits, returning the *array* of `Result` values obtained for each qubit.
 In some cases this can be optimized. 
 It has signature (`Qubit[] => Result[])`.
 `MultiM(qs)` is equivalent to:

--- a/articles/user-guide/libraries/standard/prelude.md
+++ b/articles/user-guide/libraries/standard/prelude.md
@@ -4,7 +4,7 @@ description: Learn about the intrinsic operations and functions in the QDK, incl
 author: QuantumWriter
 ms.author: martinro
 ms.date: 12/11/2017
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.libraries.standard.prelude
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/machines/full-state-simulator.md
+++ b/articles/user-guide/machines/full-state-simulator.md
@@ -1,7 +1,7 @@
 ---
 title: Full state quantum simulator - Quantum Development Kit
 description: Learn how to run your Q# programs on the Microsoft Quantum Development Kit full state simulator.
-author: anpaz-msft
+author: anpaz
 ms.author: anpaz
 ms.date: 06/26/2020 
 ms.topic: conceptual

--- a/articles/user-guide/machines/full-state-simulator.md
+++ b/articles/user-guide/machines/full-state-simulator.md
@@ -4,7 +4,7 @@ description: Learn how to run your Q# programs on the Microsoft Quantum Developm
 author: anpaz-msft
 ms.author: anpaz
 ms.date: 06/26/2020 
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.machines.full-state-simulator
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/machines/index.md
+++ b/articles/user-guide/machines/index.md
@@ -4,7 +4,7 @@ description: Describes the quantum simulators available as target machines for Q
 author: QuantumWriter
 ms.author: v-benbra 
 ms.date: 6/17/2020
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.machines
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/machines/qc-trace-simulator/depth-counter.md
+++ b/articles/user-guide/machines/qc-trace-simulator/depth-counter.md
@@ -4,7 +4,7 @@ description: Learn about the Microsoft QDK depth counter, which uses the Quantum
 author: vadym-kl
 ms.author: vadym
 ms.date: 06/25/2020
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.machines.qc-trace-simulator.depth-counter
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/machines/qc-trace-simulator/distinct-inputs-checker.md
+++ b/articles/user-guide/machines/qc-trace-simulator/distinct-inputs-checker.md
@@ -4,7 +4,7 @@ description: Learn about the Microsoft QDK distinct inputs checker, which uses t
 author: vadym-kl
 ms.author: vadym
 ms.date: 06/25/2020
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.machines.qc-trace-simulator.distinct-inputs
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/machines/qc-trace-simulator/index.md
+++ b/articles/user-guide/machines/qc-trace-simulator/index.md
@@ -5,7 +5,7 @@ description: Learn how to use the Microsoft quantum computer trace simulator to 
 author: vadym-kl 
 ms.author: vadym 
 ms.date: 06/25/2020 
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.machines.qc-trace-simulator.intro
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/machines/qc-trace-simulator/invalidated-qubits-use-checker.md
+++ b/articles/user-guide/machines/qc-trace-simulator/invalidated-qubits-use-checker.md
@@ -4,7 +4,7 @@ description: Learn about the Microsoft QDK invalidated qubits use checker, which
 author: vadym-kl
 ms.author: vadym
 ms.date: 06/25/2020
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.machines.qc-trace-simulator.invalidated-qubits
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/machines/qc-trace-simulator/primitive-operations-counter.md
+++ b/articles/user-guide/machines/qc-trace-simulator/primitive-operations-counter.md
@@ -4,7 +4,7 @@ description: Learn about the Microsoft QDK primitive operation counter, which us
 author: vadym-kl
 ms.author: vadym
 ms.date: 06/25/2020
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.machines.qc-trace-simulator.primitive-counter
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/machines/qc-trace-simulator/primitive-operations-counter.md
+++ b/articles/user-guide/machines/qc-trace-simulator/primitive-operations-counter.md
@@ -27,7 +27,7 @@ var sim = new QCTraceSimulator(config);
 
 ## Using the primitive operation counter in a C# host program
 
-The C# example that follows in this section counts how many <xref:Microsoft.Quantum.Intrinsic.T> operations are needed to implement the <xref:Microsoft.Quantum.Intrinsic.ccnot> operation, based on the following Q# sample code:
+The C# example that follows in this section counts how many <xref:Microsoft.Quantum.Intrinsic.T> operations are needed to implement the <xref:Microsoft.Quantum.Intrinsic.CCNOT> operation, based on the following Q# sample code:
 
 ```qsharp
 open Microsoft.Quantum.Intrinsic;

--- a/articles/user-guide/machines/qc-trace-simulator/width-counter.md
+++ b/articles/user-guide/machines/qc-trace-simulator/width-counter.md
@@ -4,7 +4,7 @@ description: Learn about the Microsoft QDK width counter, which uses the Quantum
 author: vadym-kl
 ms.author: vadym
 ms.date: 06/25/2020
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.machines.qc-trace-simulator.width-counter
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/machines/resources-estimator.md
+++ b/articles/user-guide/machines/resources-estimator.md
@@ -4,7 +4,7 @@ description: Learn about the Microsoft QDK resources estimator, which estimates 
 author: anpaz-msft
 ms.author: anpaz 
 ms.date: 06/26/2020
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.machines.resources-estimator
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/machines/resources-estimator.md
+++ b/articles/user-guide/machines/resources-estimator.md
@@ -1,7 +1,7 @@
 ---
 title: Quantum resources estimator - Quantum Development Kit
 description: Learn about the Microsoft QDK resources estimator, which estimates the resources required to run a given instance of a Q# operation on a quantum computer.
-author: anpaz-msft
+author: anpaz
 ms.author: anpaz 
 ms.date: 06/26/2020
 ms.topic: conceptual

--- a/articles/user-guide/machines/toffoli-simulator.md
+++ b/articles/user-guide/machines/toffoli-simulator.md
@@ -4,7 +4,7 @@ description: Learn about the Microsoft QDK Toffoli simulator, a special purpose 
 author: alan-geller
 ms.author: ageller 
 ms.date: 6/25/2020
-ms.topic: article
+ms.topic: conceptual
 uid: microsoft.quantum.machines.toffoli-simulator
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/quickref/index.md
+++ b/articles/user-guide/quickref/index.md
@@ -4,6 +4,7 @@ description: Quick reference pages for Q#
 author: gillenhaalb
 ms.author:  a-gibec
 ms.date: 03/05/2020
+ms.topic: reference
 uid: microsoft.quantum.guide.quickref
 no-loc: ['Q#', '$$v']
 ---

--- a/articles/user-guide/quickref/iqsharp.md
+++ b/articles/user-guide/quickref/iqsharp.md
@@ -4,6 +4,7 @@ description: Quick reference page for IQ# magic commands with Q# Jupyter Noteboo
 author: gillenhaalb
 ms.author:  a-gibec
 ms.date: 03/05/2020
+ms.topic: reference
 uid: microsoft.quantum.guide.quickref.iqsharp
 no-loc: ['Q#', '$$v']
 ---


### PR DESCRIPTION
Assigning the correct ms.topic values to each topic in order to better track SEO stats, page views, etc.  Currently, most topics are assigned 'article', which is a valid generic value, but doesn't help with tracking. 